### PR TITLE
🩹 fix: Unfolding in Check rules

### DIFF
--- a/src/elaborator/Elaborator.ml
+++ b/src/elaborator/Elaborator.ml
@@ -107,8 +107,10 @@ and check ?(fallback_infer=true) tm : T.check =
 (* the public interface *)
 
 let trap (f : unit -> 'a) : ('a, Errors.t) Result.t =
-  R.Eff.trap f |> Result.map_error @@ function
-  | R.Errors.Conversion (u, v) -> Errors.Conversion (u, v)
+  try Result.ok (f ()) with
+    | R.Eff.Error (R.Errors.Conversion (u,v)) -> Result.error (Errors.Conversion (u,v))
+    | Eff.Error e -> Result.error e
+
 
 let infer_top lhs tm =
   trap @@ fun () ->

--- a/src/elaborator/Elaborator.ml
+++ b/src/elaborator/Elaborator.ml
@@ -69,10 +69,6 @@ let rec infer tm : T.infer =
     (* Format.eprintf "@[<2>Could@ not@ infer@ the@ type@ of@ %a@]@." Syntax.dump tm; *)
     Eff.not_inferable ~tm
 
-(* The [fallback_infer] parameter is for the two-stage type checking: first round,
-   we try to check things without unfolding the type, and then we unfold the type
-   if type inference also fails. During the second round, we do not want to try
-   the type inference again becouse it will have already failed once. *)
 and check tm : T.check =
   match tm.CS.node with
   | CS.Pi (base, name, fam) ->

--- a/src/elaborator/Elaborator.ml
+++ b/src/elaborator/Elaborator.ml
@@ -73,7 +73,7 @@ let rec infer tm : T.infer =
    we try to check things without unfolding the type, and then we unfold the type
    if type inference also fails. During the second round, we do not want to try
    the type inference again becouse it will have already failed once. *)
-and check ?(fallback_infer=true) tm : T.check =
+and check tm : T.check =
   match tm.CS.node with
   | CS.Pi (base, name, fam) ->
     R.Pi.pi ~name ~cbase:(check base) ~cfam:(fun _ -> check fam)
@@ -89,19 +89,7 @@ and check ?(fallback_infer=true) tm : T.check =
     R.Univ.univ (check_shift s)
   | CS.Hole ->
     unleash_hole
-  | _ when fallback_infer ->
-    begin
-      T.Check.peek @@ fun goal ->
-      T.Check.orelse (T.Check.infer (infer tm)) @@ fun exn ->
-      match exn, goal.tp with
-      | Eff.Error NotInferable _, D.Unfold _ ->
-        T.Check.forcing @@ check ~fallback_infer:false tm
-      | _ ->
-        Eff.ill_typed ~tm ~tp:goal.tp
-    end
-  | _ ->
-    T.Check.peek @@ fun goal ->
-    Eff.ill_typed ~tm ~tp:goal.tp
+  | _ -> T.Check.infer (infer tm)
 
 
 (* the public interface *)

--- a/src/refiner/Rule.ml
+++ b/src/refiner/Rule.ml
@@ -25,13 +25,11 @@ struct
 
   type t = goal -> result
 
-  let rule t = t
+  let rule t goal = t {goal with tp = NbE.force_all goal.tp}
   let run goal t = t goal
-  let peek t goal = t goal goal
-
-  let forcing (t : t) : t =
-    fun goal ->
-    t {goal with tp = NbE.force_all goal.tp}
+  let peek t =
+    rule @@ fun goal -> 
+    t goal goal
 
   let infer (inf : infer) : t =
     fun goal ->
@@ -40,7 +38,7 @@ struct
     | NbE.Unequal -> Eff.not_convertible goal.tp tp'
 
   let orelse t k : t =
-    fun goal ->
+    rule @@ fun goal ->
     try t goal with
     | exn ->
       k exn goal

--- a/src/refiner/Sigs.ml
+++ b/src/refiner/Sigs.ml
@@ -19,7 +19,6 @@ sig
   val peek : (goal -> t) -> t
   val orelse : t -> (exn -> t) -> t
   val infer : infer -> t
-  val forcing : t -> t
 end
 
 module type ShiftPublic =

--- a/src/refiner/rules/Pi.ml
+++ b/src/refiner/rules/Pi.ml
@@ -4,7 +4,7 @@ let pi ~name ~cbase ~cfam : T.check =
   Quantifier.quantifier ~name ~cbase ~cfam S.pi
 
 let vir_pi ~name ~cbase ~cfam : T.check =
-  Quantifier.vir_quantifier ~name ~cbase ~cfam S.pi
+  Quantifier.vir_quantifier ~name ~cbase ~cfam S.vir_pi
 
 let lam ~name ~cbnd : T.check =
   T.Check.rule @@ fun goal ->


### PR DESCRIPTION
Fixes #9
This PR simplifies and corrects the way that the elaborator/refiner handle unfolding.
The Philosophy:
* `Check` tactics defined by the _user_ (of `Check`) should always have their goals unfolded. All our currently existing user defined check tactics need this, and I think it will be robust to new additions. Not doing so violates the thesis of the bidirectional doctrine, that we should propagate type information into terms. The type `Unfold _` has no information to propagate!
* `Check.infer` should _not_ unfold the goal. When we infer the type of term, we may get an `Unfold` type, which we can quickly check for convertibility with an `Unfold` goal, so we want to leave the goal alone. This tactic is defined within the implementation of `Check`, so it is fine to make it special.

This PR also fixes two minor bugs.
1. `Elaborator.trap` did not actually trap any elaborator errors, only refiner errors
2. The `Pi.vir_pi` tactic created `S.Pi` terms instead of `S.VirPi` terms