### PR TITLE
feat: 🛐 Worship Asai

### DIFF
--- a/algaett.opam
+++ b/algaett.opam
@@ -20,12 +20,14 @@ depends: [
   "bantorra"
   "yuujinchou"
   "mugen"
+  "asai"
 ]
 pin-depends: [
   [ "bantorra.0.2.0~dev" "git+https://github.com/RedPRL/bantorra" ]
   [ "yuujinchou.4.0.0~dev" "git+https://github.com/RedPRL/yuujinchou" ]
   [ "emoji.1.2.0~pre" "git+https://github.com/fxfactorial/ocaml-emoji" ]
   [ "mugen.0.1.0~dev" "git+https://github.com/RedPRL/mugen" ]
+  [ "asai.~dev" "git+https://github.com/RedPRL/asai"]
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/src/bin/Main.ml
+++ b/src/bin/Main.ml
@@ -1,3 +1,4 @@
 let () = Printexc.record_backtrace true
 
-let () = exit @@ Loader.load (`File Sys.argv.(1))
+let () = 
+  exit @@ Loader.load (`File Sys.argv.(1))

--- a/src/bin/Main.ml
+++ b/src/bin/Main.ml
@@ -1,3 +1,3 @@
 let () = Printexc.record_backtrace true
 
-let () = Loader.load (`File Sys.argv.(1))
+let () = exit @@ Loader.load (`File Sys.argv.(1))

--- a/src/elaborator/Eff.mli
+++ b/src/elaborator/Eff.mli
@@ -1,7 +1,7 @@
 module type Handler =
 sig
   include Refiner.Eff.Handler
-  val unleash : Syntax.bound_name -> Refiner.ResolveData.t -> Syntax.name
+  val unleash : Asai.Span.t -> Syntax.bound_name -> Refiner.ResolveData.t -> Syntax.name
 end
 
 module Run (H : Handler) :
@@ -11,8 +11,3 @@ end
 
 module Perform : Handler
 include module type of Perform
-
-exception Error of Errors.t
-
-val not_inferable : tm:Syntax.t -> 'a
-val ill_typed : tm:Syntax.t -> tp:NbE.Domain.t -> 'a

--- a/src/elaborator/Elaborator.ml
+++ b/src/elaborator/Elaborator.ml
@@ -56,7 +56,7 @@ let infer_var p s : T.infer =
     R.Structural.global_var p (check_shift s)
 
 let rec infer tm : T.infer =
-  Doctor.locate tm.span @@ fun () ->
+  T.Infer.locate tm.span @@
   match tm.value with
   | CS.Var (p, s) ->
     infer_var p s
@@ -74,7 +74,7 @@ let rec infer tm : T.infer =
     Doctor.build ~code:NotInferable ~cause ~message |> Doctor.fatal
 
 and check tm : T.check =
-  Doctor.locate tm.span @@ fun () ->
+  T.Check.locate tm.span @@
   match tm.value with
   | CS.Pi (base, name, fam) ->
     R.Pi.pi ~name ~cbase:(check base) ~cfam:(fun _ -> check fam)

--- a/src/elaborator/Elaborator.ml
+++ b/src/elaborator/Elaborator.ml
@@ -69,7 +69,7 @@ let rec infer tm : T.infer =
   | CS.Snd tm ->
     R.Sigma.snd ~itm:(infer tm)
   | _ ->
-    let message = Format.asprintf "@[<2>Could@ not@ infer@ the@ type@ of@ %a@]@." Syntax.dump tm in
+    let message = Format.asprintf "Could not infer the type of %a" Syntax.dump tm in
     let cause = "Could not infer the type of this term" in
     Doctor.build ~code:NotInferable ~cause ~message |> Doctor.fatal
 

--- a/src/elaborator/Elaborator.ml
+++ b/src/elaborator/Elaborator.ml
@@ -49,7 +49,7 @@ let infer_var p s : T.infer =
   | Some (cell, ()), None ->
     R.Structural.local_var cell
   | Some _, Some _ ->
-    let message = Format.asprintf "Local variable %a could not have level shifting" Syntax.dump_name p in
+    let message = Format.asprintf "Cannot level shift local variable `%a`" Syntax.dump_name p in
     let cause = "You're trying to shift this local variable" in
     Doctor.build ~code:NotInferable ~cause ~message |> Doctor.fatal
   | None, _ ->

--- a/src/elaborator/Elaborator.ml
+++ b/src/elaborator/Elaborator.ml
@@ -49,8 +49,8 @@ let infer_var p s : T.infer =
   | Some (cell, ()), None ->
     R.Structural.local_var cell
   | Some _, Some _ ->
-    let message = Format.asprintf "Cannot level shift local variable `%a`" Syntax.dump_name p in
-    let cause = "You're trying to shift this local variable" in
+    let message = Format.dprintf "Cannot level shift local variable `%a`" Syntax.dump_name p in
+    let cause = Format.dprintf "You're trying to shift this local variable" in
     Doctor.build ~code:NotInferable ~cause ~message |> Doctor.fatal
   | None, _ ->
     R.Structural.global_var p (check_shift s)
@@ -69,8 +69,8 @@ let rec infer tm : T.infer =
   | CS.Snd tm ->
     R.Sigma.snd ~itm:(infer tm)
   | _ ->
-    let message = Format.asprintf "Could not infer the type of %a" Syntax.dump tm in
-    let cause = "Could not infer the type of this term" in
+    let message = Format.dprintf "Could not infer the type of %a" Syntax.dump tm in
+    let cause = Format.dprintf "Could not infer the type of this term" in
     Doctor.build ~code:NotInferable ~cause ~message |> Doctor.fatal
 
 and check tm : T.check =

--- a/src/elaborator/Elaborator.mli
+++ b/src/elaborator/Elaborator.mli
@@ -1,7 +1,6 @@
 module Syntax : module type of Syntax
-module Errors : module type of Errors
 module Eff : module type of Eff
 
-val infer_top : NbE.LHS.t -> Syntax.t -> (NbE.Syntax.t * NbE.Domain.t, Errors.t) result
-val check_tp_top : NbE.LHS.t -> Syntax.t -> (NbE.Syntax.t, Errors.t) result
-val check_top : NbE.LHS.t -> Syntax.t -> tp:NbE.Domain.t -> (NbE.Syntax.t, Errors.t) result
+val infer_top : NbE.LHS.t -> Syntax.t -> NbE.Syntax.t * NbE.Domain.t
+val check_tp_top : NbE.LHS.t -> Syntax.t -> NbE.Syntax.t
+val check_top : NbE.LHS.t -> Syntax.t -> tp:NbE.Domain.t -> NbE.Syntax.t

--- a/src/elaborator/Errors.ml
+++ b/src/elaborator/Errors.ml
@@ -1,4 +1,0 @@
-type t =
-  | NotInferable of {tm : Syntax.t}
-  | IllTyped of {tm : Syntax.t; tp : NbE.Domain.t}
-  | Conversion of NbE.Domain.t * NbE.Domain.t

--- a/src/elaborator/Syntax.ml
+++ b/src/elaborator/Syntax.ml
@@ -1,21 +1,4 @@
-type span =
-  {start : Lexing.position;
-   stop : Lexing.position}
-
-let dump_position fmt Lexing.{pos_fname; pos_lnum; pos_bol; pos_cnum} =
-  Format.fprintf fmt "@[<2>{ pos_fname = \"%s\";@ pos_lnum = %i;@ pos_bol = %i;@ pos_cnum = %i; }@]"
-    (String.escaped pos_fname) pos_lnum pos_bol pos_cnum
-
-let dump_span fmt {start; stop} =
-  Format.fprintf fmt "@[<2>{ start = @[%a@];@ stop = @[%a@]; }@]" dump_position start dump_position stop
-
-type 'a node = {node : 'a; loc : span option}
-
-let dump_node dump fmt {node; loc} =
-  match loc with
-  | None -> dump fmt node
-  | Some loc ->
-    Format.fprintf fmt "@[<2>{ node = @[%a@];@ loc = @[%a@]; }@]" dump node dump_span loc
+open Asai
 
 type name = Yuujinchou.Trie.path
 
@@ -37,7 +20,7 @@ let dump_shift fmt =
   function
   | Translate i -> Format.fprintf fmt "+%i" i
 
-type t = t_ node
+type t = t_ Loc.t
 and t_ =
   | Ann of {tm : t; tp : t}
   | Var of name * shift list option
@@ -56,8 +39,8 @@ let dump_shifts fmt ss =
   Format.fprintf fmt "@[%a@]"
     (Format.pp_print_list ~pp_sep:(fun fmt () -> Format.pp_print_string fmt ";") dump_shift) ss
 
-let rec dump fmt =
-  dump_node dump_ fmt
+let rec dump fmt ({value ; _} : t) =
+  dump_ fmt value
 
 and dump_ fmt =
   function

--- a/src/elaborator/dune
+++ b/src/elaborator/dune
@@ -2,5 +2,5 @@
  (name Elaborator)
  (flags
   (:standard -w -32-37-38-27-26-79-39 -warn-error -a+31))
- (libraries bwd algaeff mugen yuujinchou algaett.nbe algaett.refiner)
+ (libraries asai bwd algaeff mugen yuujinchou algaett.nbe algaett.refiner algaett.error)
  (public_name algaett.elaborator))

--- a/src/error/doctor.ml
+++ b/src/error/doctor.ml
@@ -1,0 +1,32 @@
+module ErrorCode =
+struct
+  type t =
+    | NotInScope
+    | NotInferable
+    | IllTyped
+    | Conversion
+  
+  let severity = let open Asai.Severity in function
+    | NotInScope -> Error
+    | NotInferable -> Error
+    | IllTyped -> Error
+    | Conversion -> Error
+  
+  let code_num = function
+    | NotInScope -> 0
+    | NotInferable -> 1
+    | IllTyped -> 2
+    | Conversion -> 3
+
+  let description = function
+    | NotInScope -> 
+      "We encountered an out of scope variable"
+    | NotInferable ->
+      "We encountered a term for which we could not infer a type"
+    | IllTyped ->
+      "We encountered an ill typed term"
+    | Conversion ->
+      "We expected two terms to be convertible but they are not"
+end
+
+include Asai.Effects.Make(ErrorCode)

--- a/src/error/doctor.ml
+++ b/src/error/doctor.ml
@@ -49,11 +49,11 @@ let dump_conn fmt : connective -> _ = function
   | `TpULvl -> Format.fprintf fmt "TpULvl"
 
 let expected_connective_check conn fmt x =
-  let message = Format.asprintf "You are trying to construct an element of a %a type but you are checking against %a" dump_conn conn fmt x in
-  let cause = Format.asprintf "This term cannot be checked against %a" fmt x in
+  let message = Format.dprintf "You are trying to construct an element of a %a type but you are checking against %a" dump_conn conn fmt x in
+  let cause = Format.dprintf "This term cannot be checked against %a" fmt x in
   build ~code:IllTyped ~cause ~message |> fatal
 
 let expected_connective_infer conn fmt x =
-  let message = Format.asprintf "You are trying to eliminate an element of a %a type but you have an element of %a" dump_conn conn fmt x in
-  let cause = Format.asprintf "This term being eliminated in this expression does not have a %a type" dump_conn conn in
+  let message = Format.dprintf "You are trying to eliminate an element of a %a type but you have an element of %a" dump_conn conn fmt x in
+  let cause = Format.dprintf "This term being eliminated in this expression does not have a %a type" dump_conn conn in
   build ~code:IllTyped ~cause ~message |> fatal

--- a/src/error/doctor.ml
+++ b/src/error/doctor.ml
@@ -30,3 +30,30 @@ struct
 end
 
 include Asai.Effects.Make(ErrorCode)
+
+type connective =
+  [ `Pi
+  | `VirPi
+  | `Sigma
+  | `Univ
+  | `VirUniv
+  | `TpULvl
+  ]
+
+let dump_conn fmt : connective -> _ = function
+  | `Pi -> Format.fprintf fmt "Pi"
+  | `VirPi -> Format.fprintf fmt "Virtual Pi"
+  | `Sigma -> Format.fprintf fmt "Sigma"
+  | `Univ -> Format.fprintf fmt "Univ"
+  | `VirUniv -> Format.fprintf fmt "Virtual Univ"
+  | `TpULvl -> Format.fprintf fmt "TpULvl"
+
+let expected_connective_check conn fmt x =
+  let message = Format.asprintf "You are trying to construct an element of a %a type but you are checking against %a" dump_conn conn fmt x in
+  let cause = Format.asprintf "This term cannot be checked against %a" fmt x in
+  build ~code:IllTyped ~cause ~message |> fatal
+
+let expected_connective_infer conn fmt x =
+  let message = Format.asprintf "You are trying to eliminate an element of a %a type but you have an element of %a" dump_conn conn fmt x in
+  let cause = Format.asprintf "This term being eliminated in this expression does not have a %a type" dump_conn conn in
+  build ~code:IllTyped ~cause ~message |> fatal

--- a/src/error/dune
+++ b/src/error/dune
@@ -1,0 +1,4 @@
+(library
+ (name Error)
+ (libraries asai algaeff)
+ (public_name algaett.error))

--- a/src/interpreter/Driver.ml
+++ b/src/interpreter/Driver.ml
@@ -1,30 +1,36 @@
+open Asai
 module CS = Syntax
 module UE = UnitEffect
 
 exception Quit (* local *)
 
-let include_singleton ?loc name data =
+let include_singleton span name data =
   match name with
   | None -> ()
-  | Some p -> UE.include_singleton ?loc (p, data)
+  | Some p -> UE.include_singleton span (p, data)
 
-let rec execute_decl {CS.node = decl; CS.loc = loc} =
+let rec execute_decl {Loc.value = decl; Loc.span } =
   match decl with
   | CS.Axiom {name; tp} ->
-    let tp = NbE.eval_top @@ UE.reraise_elaborator @@ Elaborator.check_tp_top NbE.LHS.unknown tp in
-    include_singleton ?loc (name : CS.bound_name) @@ Axiom {tp}
+    let tp = NbE.eval_top @@ Elaborator.check_tp_top NbE.LHS.unknown tp in
+    include_singleton span (name : CS.bound_name) @@ Axiom {tp}
   | CS.Def {name; tm} ->
     let lhs = Option.fold ~none:NbE.LHS.unknown ~some:NbE.LHS.head name in
-    let tm, tp = UE.reraise_elaborator @@ Elaborator.infer_top lhs tm in
-    include_singleton ?loc name @@ Def {tm = lazy begin NbE.eval_top tm end; tp}
+    let tm, tp = Elaborator.infer_top lhs tm in
+    include_singleton span name @@ Def {tm = lazy begin NbE.eval_top tm end; tp}
+  | CS.DefChk {name ; tp ; tm} ->
+    let lhs = Option.fold ~none:NbE.LHS.unknown ~some:NbE.LHS.head name in
+    let tp = NbE.eval_top @@ Elaborator.check_tp_top NbE.LHS.unknown tp in
+    let tm = Elaborator.check_top lhs tm ~tp in
+    include_singleton span name @@ Def {tm = lazy begin NbE.eval_top tm end; tp}
   | CS.Import {unit_path; modifier} ->
-    UE.import ?loc unit_path modifier
+    UE.import span unit_path modifier
   | CS.Section {prefix; block} ->
     UE.section prefix @@ fun () -> execute_section block
   | CS.Quit -> raise Quit
 
 and execute_section sec =
-  List.iter execute_decl sec.CS.node
+  List.iter execute_decl sec.Loc.value
 
 let execute prog =
-  UnitEffect.trap @@ fun () -> try execute_section prog with Quit -> ()
+  try execute_section prog with Quit -> ()

--- a/src/interpreter/Driver.mli
+++ b/src/interpreter/Driver.mli
@@ -1,1 +1,1 @@
-val execute : Syntax.prog -> (unit, UnitEffect.error) result
+val execute : Syntax.prog -> unit

--- a/src/interpreter/Interpreter.ml
+++ b/src/interpreter/Interpreter.ml
@@ -1,16 +1,10 @@
 module Syntax = Syntax
 
-type error = UnitEffect.error =
-  | NotInScope of Yuujinchou.Trie.path
-  | NotInferable of {tm : Syntax.t}
-  | IllTyped of {tm : Syntax.t; tp : NbE.Domain.t}
-  | Conversion of NbE.Domain.t * NbE.Domain.t
-
 let execute = Driver.execute
 
 type unused_info = Used.info =
-  | Imported of Bantorra.Manager.path Elaborator.Syntax.node
-  | Local of Yuujinchou.Trie.path Elaborator.Syntax.node
+  | Imported of Bantorra.Manager.path Asai.Loc.t
+  | Local of Yuujinchou.Trie.path Asai.Loc.t
 
 module type Handler = UnitEffect.Handler
 module Run = UnitEffect.Run

--- a/src/interpreter/Interpreter.mli
+++ b/src/interpreter/Interpreter.mli
@@ -1,16 +1,10 @@
 module Syntax : module type of Syntax
 
-type error =
-  | NotInScope of Yuujinchou.Trie.path
-  | NotInferable of {tm : Syntax.t}
-  | IllTyped of {tm : Syntax.t; tp : NbE.Domain.t}
-  | Conversion of NbE.Domain.t * NbE.Domain.t
-
-val execute : Syntax.prog -> (unit, error) result
+val execute : Syntax.prog -> unit
 
 type unused_info =
-  | Imported of Bantorra.Manager.path Elaborator.Syntax.node
-  | Local of Yuujinchou.Trie.path Elaborator.Syntax.node
+  | Imported of Bantorra.Manager.path Asai.Loc.t
+  | Local of Yuujinchou.Trie.path Asai.Loc.t
 
 module type Handler = UnitEffect.Handler
 module Perform : Handler

--- a/src/interpreter/Syntax.ml
+++ b/src/interpreter/Syntax.ml
@@ -1,17 +1,20 @@
+open Asai
+
 include Elaborator.Syntax
 
 type empty = |
 type modifier = empty Yuujinchou.Language.t
 
-type cmd = cmd_ node
+type cmd = cmd_ Loc.t
 and cmd_ =
   | Axiom of {name : bound_name; tp : t}
   | Def of {name : bound_name; tm : t}
+  | DefChk of {name : bound_name; tp : t; tm : t}
   | Import of {unit_path : Bantorra.Manager.path; modifier : modifier}
   | Section of {prefix : Yuujinchou.Trie.path; block : section}
   | Quit
 
-and section = section_ node
+and section = section_ Loc.t
 and section_ = cmd list
 
 type prog = section

--- a/src/interpreter/UnitEffect.ml
+++ b/src/interpreter/UnitEffect.ml
@@ -31,12 +31,6 @@ module S =
       type context = Syntax.empty
     end)
 
-let not_in_scope n =
-  let message = Format.asprintf "Variable `%a` is not in scope" Syntax.dump_name n in
-  let cause = "This variable is not in scope" in
-  Error.Doctor.build ~code:NotInScope ~cause ~message |> Error.Doctor.fatal
-
-
 let include_singleton span (p, data) =
   let id = Used.new_ (Used.Local {value = p; span}) in
   S.include_singleton (p, (data, id))
@@ -66,8 +60,8 @@ struct
 
     let resolve p =
       match S.resolve p with
-      | None -> not_in_scope p
-      | Some (data, tag) -> Used.use tag; data
+      | None -> None
+      | Some (data, tag) -> Used.use tag; Some data
 
     let unleash span (name : Syntax.bound_name) data =
       let p =

--- a/src/interpreter/UnitEffect.mli
+++ b/src/interpreter/UnitEffect.mli
@@ -1,14 +1,5 @@
-type error =
-  | NotInScope of Yuujinchou.Trie.path
-  | NotInferable of {tm: Syntax.t}
-  | IllTyped of {tm: Syntax.t; tp: NbE.Domain.t}
-  | Conversion of NbE.Domain.t * NbE.Domain.t
-
-val reraise_elaborator : ('a, Elaborator.Errors.t) result -> 'a
-val trap : (unit -> 'a) -> ('a, error) result
-
-val include_singleton : ?loc:Elaborator.Syntax.span -> (Yuujinchou.Trie.path * Refiner.ResolveData.t) -> unit
-val import : ?loc:Elaborator.Syntax.span -> Bantorra.Manager.path -> Syntax.modifier -> unit
+val include_singleton : Asai.Span.t -> (Yuujinchou.Trie.path * Refiner.ResolveData.t) -> unit
+val import : Asai.Span.t -> Bantorra.Manager.path -> Syntax.modifier -> unit
 val section : Yuujinchou.Trie.path -> (unit -> 'a) -> 'a
 val get_export : unit -> Refiner.ResolveData.t Yuujinchou.Trie.Untagged.t
 

--- a/src/interpreter/Used.ml
+++ b/src/interpreter/Used.ml
@@ -1,6 +1,6 @@
 type info =
-  | Imported of Bantorra.Manager.path Elaborator.Syntax.node
-  | Local of Yuujinchou.Trie.path Elaborator.Syntax.node
+  | Imported of Bantorra.Manager.path Asai.Loc.t
+  | Local of Yuujinchou.Trie.path Asai.Loc.t
 
 module Internal =
 struct

--- a/src/interpreter/Used.mli
+++ b/src/interpreter/Used.mli
@@ -1,6 +1,6 @@
 type info =
-  | Imported of Bantorra.Manager.path Elaborator.Syntax.node
-  | Local of Yuujinchou.Trie.path Elaborator.Syntax.node
+  | Imported of Bantorra.Manager.path Asai.Loc.t
+  | Local of Yuujinchou.Trie.path Asai.Loc.t
 
 type id
 val compare_id : id -> id -> int

--- a/src/interpreter/dune
+++ b/src/interpreter/dune
@@ -1,4 +1,4 @@
 (library
  (name Interpreter)
- (libraries bwd algaeff bantorra yuujinchou algaett.nbe algaett.elaborator)
+ (libraries bwd algaeff bantorra yuujinchou algaett.nbe algaett.elaborator algaett.error)
  (public_name algaett.interpreter))

--- a/src/loader/Loader.ml
+++ b/src/loader/Loader.ml
@@ -1,3 +1,7 @@
+open Asai
+open Error
+module Terminal = Asai_unix.Make(Doctor.ErrorCode)
+
 module InterpreterHandler : Interpreter.Handler =
 struct
   let load _ = raise Not_found
@@ -12,7 +16,16 @@ let run_interpreter =
 
 let load =
   function
-  | `File filename ->
-    let prog = Parser.parse_file filename in
-    Result.get_ok @@ run_interpreter @@ fun () ->
+  | `File filepath ->
+    let span = Span.file_start filepath in
+    Doctor.run_display ~span ~display:Terminal.display @@ fun () ->
+    let prog = Parser.parse_file filepath in
+    let contents = 
+      let ch = open_in filepath in
+      let str = really_input_string ch (in_channel_length ch) in
+      close_in ch;
+      str
+    in
+    Error.Doctor.load_file ~filepath contents;
+    run_interpreter @@ fun () ->
     Interpreter.execute prog

--- a/src/loader/dune
+++ b/src/loader/dune
@@ -4,6 +4,9 @@
   bwd
   algaeff
   yuujinchou
+  asai
+  asai.unix
+  algaett.error
   algaett.elaborator
   algaett.interpreter
   algaett.parser)

--- a/src/nbe/Syntax.ml
+++ b/src/nbe/Syntax.ml
@@ -39,3 +39,49 @@ module ULvl =
       let level l = ULvl l
       let unlevel = function ULvl l -> Some l | _ -> None
     end)
+
+let dump_name fmt n =
+  Format.fprintf fmt "@[%a@]"
+    (Format.pp_print_list ~pp_sep:(fun fmt () -> Format.pp_print_string fmt ".") Format.pp_print_string) n
+
+let dump_shift fmt i =
+  Format.fprintf fmt "%i" (Mugen.Shift.Int.to_int i)
+
+let rec dump fmt =
+  function
+  | Var ix ->
+    Format.fprintf fmt "Var @[%i@]" ix
+  | Lam tm ->
+    Format.fprintf fmt "@[<5>Lam (@[%a@])@]" dump tm
+  | App (tm1, tm2) ->
+    Format.fprintf fmt "@[<5>App (@[%a@],@ @[%a@])@]" dump tm1 dump tm2
+  | Pair (tm1, tm2) ->
+    Format.fprintf fmt "@[<6>Pair (@[%a@],@ @[%a@])@]" dump tm1 dump tm2
+  | Fst tm ->
+    Format.fprintf fmt "Fst @[%a@]" dump tm
+  | Snd tm ->
+    Format.fprintf fmt "Snd @[%a@]" dump tm
+  | Univ l ->
+    Format.fprintf fmt "Univ @[%a@]" dump l
+  | VirPi (base, fam) ->
+    Format.fprintf fmt "@[<7>VirPi (@[%a@],@ @[%a@])@]" dump base dump fam
+  | Pi (base, fam) ->
+    Format.fprintf fmt "@[<7>Pi (@[%a@],@ @[%a@])@]" dump base dump fam
+  | Sigma (base, fam) ->
+    Format.fprintf fmt "@[<7>Sigma (@[%a@],@ @[%a@])@]" dump base dump fam
+  | TpULvl ->
+    Format.fprintf fmt "TpULvl"
+  | VirUniv ->
+    Format.fprintf fmt "VirUniv"
+  | Axiom p ->
+    Format.fprintf fmt "Axiom %a" dump_name p
+  | Def (p, _) ->
+    Format.fprintf fmt "Def %a" dump_name p
+  | ULvl l ->
+    Format.fprintf fmt "ULvl %a" dump_endo l
+
+and dump_endo fmt =
+  Mugen.Syntax.Endo.dump
+    dump_shift
+    dump
+    fmt

--- a/src/parser/Cmd.ml
+++ b/src/parser/Cmd.ml
@@ -10,7 +10,8 @@ let parser section_ = cmd*
 and section = located section_
 and parser cmd_ =
   | def name:(Term.bound_name) colon tp:(Term.term) assign tm:(Term.term) ->
-      S.Def {name; tm = {node = S.Ann {tm; tp}; loc = None}}
+     (* TODO: change this to store the tp and tm separately so we can recall their spans *)
+      S.DefChk {name; tm ; tp}
   | def name:(Term.bound_name) assign tm:(Term.term) ->
       S.Def {name; tm}
   | axiom name:(Term.bound_name) colon tp:(Term.term) ->

--- a/src/parser/Locate.ml
+++ b/src/parser/Locate.ml
@@ -10,14 +10,11 @@ let lexing_position i c =
   }
 
 let locate i1 c1 i2 c2 =
-  Elaborator.Syntax.{
-    start = lexing_position i1 c1;
-    stop = lexing_position i2 c2;
-  }
+  Asai.Span.of_lex_pos (lexing_position i1 c1) (lexing_position i2 c2)
 
 let located p =
   p |> Earley.apply_position @@ fun i1 c1 i2 c2 x ->
-  Elaborator.Syntax.{
-    node = x;
-    loc = Some (locate i1 c1 i2 c2);
+  Asai.Loc.{
+    value = x;
+    span = locate i1 c1 i2 c2;
   }

--- a/src/parser/dune
+++ b/src/parser/dune
@@ -4,6 +4,7 @@
   (action
    (run pa_ocaml %{input-file})))
  (libraries
+  asai
   bwd
   algaeff
   yuujinchou

--- a/src/refiner/Eff.ml
+++ b/src/refiner/Eff.ml
@@ -32,12 +32,6 @@ end
 
 include Perform
 
-exception Error of Errors.t
-
-let not_convertible u v = raise @@ Error (Conversion (u, v))
-
-let trap f = try Result.ok (f ()) with Error e -> Result.error e
-
 type env = {
   blessed_ulvl : D.t;
   local_names : (D.cell, unit) Yuujinchou.Trie.t;

--- a/src/refiner/Eff.ml
+++ b/src/refiner/Eff.ml
@@ -5,11 +5,11 @@ module S = NbE.Syntax
 module D = NbE.Domain
 module UL = NbE.ULvl
 
-type _ Effect.t += Resolve : Yuujinchou.Trie.path -> ResolveData.t Effect.t
+type _ Effect.t += Resolve : Yuujinchou.Trie.path -> ResolveData.t option Effect.t
 
 module type Handler =
 sig
-  val resolve : Yuujinchou.Trie.path -> ResolveData.t
+  val resolve : Yuujinchou.Trie.path -> ResolveData.t option
 end
 
 module Run (H : Handler) =

--- a/src/refiner/Eff.mli
+++ b/src/refiner/Eff.mli
@@ -4,7 +4,7 @@ val blessed_ulvl : unit -> NbE.Domain.t
 
 module type Handler =
 sig
-  val resolve : Yuujinchou.Trie.path -> ResolveData.t
+  val resolve : Yuujinchou.Trie.path -> ResolveData.t option
 end
 
 module Perform : Handler

--- a/src/refiner/Eff.mli
+++ b/src/refiner/Eff.mli
@@ -1,8 +1,4 @@
-exception Error of Errors.t
-
 val bind : name:Yuujinchou.Trie.path option -> tp:NbE.Domain.t -> (NbE.Domain.cell -> 'a) -> 'a
-
-val trap : (unit -> 'a) -> ('a, Errors.t) Result.t
 
 val blessed_ulvl : unit -> NbE.Domain.t
 
@@ -24,8 +20,6 @@ val lazy_eval : NbE.Syntax.t -> NbE.Domain.t Lazy.t
 val equate : NbE.Domain.t -> [ `EQ | `GE | `LE ] -> NbE.Domain.t -> unit
 
 val quote : NbE.Domain.t -> NbE.Syntax.t
-
-val not_convertible : NbE.Domain.t -> NbE.Domain.t -> 'a
 
 val with_top_env : (unit -> 'a) -> 'a
 

--- a/src/refiner/Errors.ml
+++ b/src/refiner/Errors.ml
@@ -1,2 +1,0 @@
-type t =
-  | Conversion of NbE.Domain.t * NbE.Domain.t

--- a/src/refiner/Refiner.ml
+++ b/src/refiner/Refiner.ml
@@ -3,7 +3,6 @@ module D = NbE.Domain
 module UL = NbE.ULvl
 module LHS = NbE.LHS
 
-module Errors = Errors
 module ResolveData = ResolveData
 module Eff = Eff
 module Tactic = Tactic

--- a/src/refiner/Refiner.mli
+++ b/src/refiner/Refiner.mli
@@ -1,4 +1,3 @@
-module Errors : module type of Errors
 module Eff : module type of Eff
 module ResolveData : module type of ResolveData
 

--- a/src/refiner/Rule.ml
+++ b/src/refiner/Rule.ml
@@ -42,8 +42,8 @@ struct
     | NbE.Unequal -> 
       let tp = Eff.quote goal.tp in
       let tp' = Eff.quote tp' in
-      let message = Format.asprintf "Expected %a to be convertible with %a" S.dump tp S.dump tp' in
-      let cause = Format.asprintf "Needed a term of type %a but got a term of type %a" S.dump tp S.dump tp' in
+      let message = Format.dprintf "Expected %a to be convertible with %a" S.dump tp S.dump tp' in
+      let cause = Format.dprintf "Needed a term of type %a but got a term of type %a" S.dump tp S.dump tp' in
       Error.Doctor.build ~code:Conversion ~cause ~message |> Error.Doctor.fatal
 
   let orelse t k : t =

--- a/src/refiner/Rule.ml
+++ b/src/refiner/Rule.ml
@@ -35,7 +35,12 @@ struct
     fun goal ->
     let tm', tp' = Infer.run Infer.{lhs = goal.lhs} inf in
     try Eff.equate tp' `LE goal.tp; tm' with
-    | NbE.Unequal -> Eff.not_convertible goal.tp tp'
+    | NbE.Unequal -> 
+      let tp = Eff.quote goal.tp in
+      let tp' = Eff.quote tp' in
+      let message = Format.asprintf "Expected %a to be convertible with %a" S.dump tp S.dump tp' in
+      let cause = Format.asprintf "Needed a term of type %a but got a term of type %a" S.dump tp S.dump tp' in
+      Error.Doctor.build ~code:Conversion ~cause ~message |> Error.Doctor.fatal
 
   let orelse t k : t =
     rule @@ fun goal ->

--- a/src/refiner/Rule.ml
+++ b/src/refiner/Rule.ml
@@ -14,6 +14,10 @@ struct
   type t = goal -> result
   let rule t = t
   let run goal t = t goal
+
+  let locate span t goal =
+    Error.Doctor.locate span @@ fun () ->
+    run goal t
 end
 
 type infer = Infer.t
@@ -47,6 +51,10 @@ struct
     try t goal with
     | exn ->
       k exn goal
+      
+  let locate span t goal =
+    Error.Doctor.locate span @@ fun () ->
+    run goal t
 end
 
 type check = Check.t

--- a/src/refiner/Sigs.ml
+++ b/src/refiner/Sigs.ml
@@ -4,6 +4,7 @@ sig
   type goal = {lhs : NbE.LHS.t}
   type result = NbE.Syntax.t * NbE.Domain.t
   val run : goal -> t -> result
+  val locate : Asai.Span.t -> t -> t
 end
 
 module type CheckPublic =
@@ -19,6 +20,7 @@ sig
   val peek : (goal -> t) -> t
   val orelse : t -> (exn -> t) -> t
   val infer : infer -> t
+  val locate : Asai.Span.t -> t -> t
 end
 
 module type ShiftPublic =

--- a/src/refiner/dune
+++ b/src/refiner/dune
@@ -2,7 +2,7 @@
  (name Refiner)
  (flags
   (:standard -w -32-37-38-27-26-79-39 -warn-error -a+31))
- (libraries bwd algaeff mugen yuujinchou algaett.nbe)
+ (libraries bwd algaeff mugen yuujinchou algaett.nbe algaett.error)
  (public_name algaett.refiner))
 
 (include_subdirs unqualified)

--- a/src/refiner/rules/Pi.ml
+++ b/src/refiner/rules/Pi.ml
@@ -1,10 +1,10 @@
 open RuleKit
 
 let pi ~name ~cbase ~cfam : T.check =
-  Quantifier.quantifier ~name ~cbase ~cfam S.pi
+  Quantifier.quantifier ~conn:`Pi ~name ~cbase ~cfam S.pi
 
 let vir_pi ~name ~cbase ~cfam : T.check =
-  Quantifier.vir_quantifier ~name ~cbase ~cfam S.vir_pi
+  Quantifier.vir_quantifier ~conn:`VirPi ~name ~cbase ~cfam S.vir_pi
 
 let lam ~name ~cbnd : T.check =
   T.Check.rule @@ fun goal ->
@@ -13,8 +13,8 @@ let lam ~name ~cbnd : T.check =
     Eff.bind ~name ~tp:base @@ fun arg ->
     let fib = NbE.inst_clo' fam @@ arg.D.tm in
     S.lam @@ T.Check.run {tp = fib; lhs = LHS.app goal.lhs arg} @@ cbnd arg
-  | _ ->
-    invalid_arg "lam"
+  | tp ->
+    E.Doctor.expected_connective_check `Pi S.dump (Eff.quote tp)
 
 let app ~itm ~ctm : T.infer =
   T.Infer.rule @@ fun _ ->
@@ -24,5 +24,5 @@ let app ~itm ~ctm : T.infer =
     let arg = T.Check.run {tp = base; lhs = LHS.unknown} ctm in
     let fib = NbE.inst_clo fam @@ Eff.lazy_eval arg in
     S.app fn arg, fib
-  | _ ->
-    invalid_arg "app"
+  | tp ->
+    E.Doctor.expected_connective_infer `Pi S.dump (Eff.quote tp)

--- a/src/refiner/rules/Quantifier.ml
+++ b/src/refiner/rules/Quantifier.ml
@@ -1,13 +1,14 @@
 open RuleKit
 
 type rule =
-  name:Yuujinchou.Trie.path option
+  conn:E.Doctor.connective
+  -> name:Yuujinchou.Trie.path option
   -> cbase:T.check
   -> cfam:T.check T.binder
   -> (S.t -> S.t -> S.t)
   -> T.check
 
-let auxiliary ~name ~cbase ~cbase_sort ~cfam builder : T.check =
+let auxiliary ~conn ~name ~cbase ~cbase_sort ~cfam builder : T.check =
   T.Check.rule @@ fun goal ->
   match goal.tp with
   | D.Univ _ ->
@@ -19,11 +20,12 @@ let auxiliary ~name ~cbase ~cbase_sort ~cfam builder : T.check =
     in
     builder base fam
   | _ ->
-    invalid_arg "quantifier"
+    let tp = Eff.quote goal.tp in
+    E.Doctor.expected_connective_check conn S.dump tp
 
 
-let quantifier ~name ~cbase ~cfam builder : T.check =
-  auxiliary ~name ~cbase ~cbase_sort:(fun univ -> univ) ~cfam builder
+let quantifier ~conn ~name ~cbase ~cfam builder : T.check =
+  auxiliary ~conn ~name ~cbase ~cbase_sort:(fun univ -> univ) ~cfam builder
 
-let vir_quantifier ~name ~cbase ~cfam builder : T.check =
-  auxiliary ~name ~cbase ~cbase_sort:(fun _ -> D.VirUniv) ~cfam builder
+let vir_quantifier ~conn ~name ~cbase ~cfam builder : T.check =
+  auxiliary ~conn ~name ~cbase ~cbase_sort:(fun _ -> D.VirUniv) ~cfam builder

--- a/src/refiner/rules/Quantifier.mli
+++ b/src/refiner/rules/Quantifier.mli
@@ -1,7 +1,8 @@
 open Tactic
 
 type rule =
-  name:Yuujinchou.Trie.path option
+  conn:Error.Doctor.connective
+  -> name:Yuujinchou.Trie.path option
   -> cbase:check
   -> cfam:check binder
   -> (NbE.Syntax.t -> NbE.Syntax.t -> NbE.Syntax.t)

--- a/src/refiner/rules/RuleKit.ml
+++ b/src/refiner/rules/RuleKit.ml
@@ -3,3 +3,4 @@ module D = NbE.Domain
 module UL = NbE.ULvl
 module LHS = NbE.LHS
 module T = Rule
+module E = Error

--- a/src/refiner/rules/Sigma.ml
+++ b/src/refiner/rules/Sigma.ml
@@ -1,7 +1,7 @@
 open RuleKit
 
 let sigma ~name ~cbase ~cfam : T.check =
-  Quantifier.quantifier ~name ~cbase ~cfam S.sigma
+  Quantifier.quantifier ~conn:`Sigma ~name ~cbase ~cfam S.sigma
 
 let pair ~cfst ~csnd : T.check =
   T.Check.rule @@ fun goal ->
@@ -11,8 +11,8 @@ let pair ~cfst ~csnd : T.check =
     let tp2 = NbE.inst_clo fam @@ Eff.lazy_eval tm1 in
     let tm2 = T.Check.run {tp = tp2; lhs = LHS.snd goal.lhs} csnd in
     S.pair tm1 tm2
-  | _ ->
-    invalid_arg "pair"
+  | tp ->
+    E.Doctor.expected_connective_check `Sigma S.dump (Eff.quote tp)
 
 let fst ~itm : T.infer =
   T.Infer.rule @@ fun _ ->
@@ -21,7 +21,7 @@ let fst ~itm : T.infer =
   | D.Sigma (base, _) ->
     S.fst tm, base
   | _ ->
-    invalid_arg "fst"
+    E.Doctor.expected_connective_infer`Sigma S.dump (Eff.quote tp)
 
 let snd ~itm : T.infer =
   T.Infer.rule @@ fun _ ->
@@ -31,4 +31,4 @@ let snd ~itm : T.infer =
     let tp = NbE.inst_clo fam @@ Eff.lazy_eval @@ S.fst tm in
     S.snd tm, tp
   | _ ->
-    invalid_arg "snd"
+    E.Doctor.expected_connective_infer `Sigma S.dump (Eff.quote tp)

--- a/src/refiner/rules/Structural.ml
+++ b/src/refiner/rules/Structural.ml
@@ -21,8 +21,8 @@ let global_var path shift : T.infer =
     | Some (ResolveData.Axiom {tp}) -> S.axiom path, tp
     | Some (ResolveData.Def {tp; tm}) -> S.def path tm, tp
     | None ->
-      let message = Format.asprintf "Variable `%a` is not in scope" S.dump_name path in
-      let cause = "This variable is not in scope" in
+      let message = Format.dprintf "Variable `%a` is not in scope" S.dump_name path in
+      let cause = Format.dprintf "This variable is not in scope" in
       Error.Doctor.build ~code:NotInScope ~cause ~message |> Error.Doctor.fatal
   in
   S.app tm (Eff.quote ulvl), NbE.app_ulvl ~tp ~ulvl

--- a/src/refiner/rules/Structural.ml
+++ b/src/refiner/rules/Structural.ml
@@ -18,8 +18,12 @@ let global_var path shift : T.infer =
   let ulvl = T.Shift.run shift in
   let tm, tp =
     match Eff.resolve path with
-    | ResolveData.Axiom {tp} -> S.axiom path, tp
-    | ResolveData.Def {tp; tm} -> S.def path tm, tp
+    | Some (ResolveData.Axiom {tp}) -> S.axiom path, tp
+    | Some (ResolveData.Def {tp; tm}) -> S.def path tm, tp
+    | None ->
+      let message = Format.asprintf "Variable `%a` is not in scope" S.dump_name path in
+      let cause = "This variable is not in scope" in
+      Error.Doctor.build ~code:NotInScope ~cause ~message |> Error.Doctor.fatal
   in
   S.app tm (Eff.quote ulvl), NbE.app_ulvl ~tp ~ulvl
 

--- a/src/refiner/rules/Univ.ml
+++ b/src/refiner/rules/Univ.ml
@@ -9,11 +9,11 @@ let univ shift =
     then S.univ (Eff.quote vsmall)
     else begin
       let pp_lvl = Mugen.Syntax.Free.dump NbE.ULvl.Shift.dump Format.pp_print_int in
-      let message = Format.asprintf "@[<2>Universe@ level@ %a@ is@ not@ smaller@ than@ %a@]@."
+      let message = Format.dprintf "@[<2>Universe@ level@ %a@ is@ not@ smaller@ than@ %a@]@."
         pp_lvl (UL.of_con vsmall)
         pp_lvl (UL.of_con large)
       in
-      let cause = "This type is too large to fit in the universe it is being checked against" in
+      let cause = Format.dprintf "This type is too large to fit in the universe it is being checked against" in
       E.Doctor.build ~code:IllTyped ~cause ~message |> E.Doctor.fatal
     end
   | tp ->

--- a/src/refiner/rules/Univ.ml
+++ b/src/refiner/rules/Univ.ml
@@ -9,10 +9,12 @@ let univ shift =
     then S.univ (Eff.quote vsmall)
     else begin
       let pp_lvl = Mugen.Syntax.Free.dump NbE.ULvl.Shift.dump Format.pp_print_int in
-      Format.eprintf "@[<2>Universe@ level@ %a@ is@ not@ smaller@ than@ %a@]@."
+      let message = Format.asprintf "@[<2>Universe@ level@ %a@ is@ not@ smaller@ than@ %a@]@."
         pp_lvl (UL.of_con vsmall)
-        pp_lvl (UL.of_con large);
-      invalid_arg "univ"
+        pp_lvl (UL.of_con large)
+      in
+      let cause = "This type is too large to fit in the universe it is being checked against" in
+      E.Doctor.build ~code:IllTyped ~cause ~message |> E.Doctor.fatal
     end
-  | _ ->
-    invalid_arg "univ"
+  | tp ->
+    E.Doctor.expected_connective_check `Univ S.dump (Eff.quote tp)


### PR DESCRIPTION
Closes #18  
Helps with #16 
This PR ditches the low Ch'i "errors are sum types that we propagate with exceptions and sometimes catch" approach to error messages, and adopts the Asai library, where errors are effects that carry diagnostic information. 

The exact error messages that are being used now are not final, and we should strive to continually make them more useful!

This PR will actually not work until Asai is updated to fix some bugs. Namely we need to allow newlines in error messages, and we need to avoid out-of-bounds string indexing in `uft8_slice_lines`.

To get Asai working you will need to
```
opam repo add alpha git+https://github.com/kit-ty-kate/opam-alpha-repository.git
```
Asai also pins `algaeff` to the github repo, while `algaett` just uses the package on opam.

To get ocaml-lsp-server working with VSCode _and_ Asai you will need to
```
opam pin git+https://github.com/patricoferris/ocaml-lsp#87ab11a7a88b6e47205736d972c3c4af79ee2a7e
opam unpin lsp
opam unpin jsonrpc
opam install lsp
opam install jsonrpc
```

This stuff should get put in a `Makefile`