### PR TITLE
fix(nbe): use thread-safe, blocking lazy expressions

### DIFF
--- a/src/interpreter/Driver.ml
+++ b/src/interpreter/Driver.ml
@@ -16,7 +16,7 @@ let rec execute_decl {CS.node = decl; CS.loc = loc} =
   | CS.Def {name; tm} ->
     let lhs = Option.fold ~none:NbE.LHS.unknown ~some:NbE.LHS.head name in
     let tm, tp = UE.reraise_elaborator @@ Elaborator.infer_top lhs tm in
-    include_singleton ?loc name @@ Def {tm = lazy begin NbE.eval_top tm end; tp}
+    include_singleton ?loc name @@ Def {tm = SyncLazy.from_lazy @@ lazy begin NbE.eval_top tm end; tp}
   | CS.Import {unit_path; modifier} ->
     UE.import ?loc unit_path modifier
   | CS.Section {prefix; block} ->

--- a/src/interpreter/dune
+++ b/src/interpreter/dune
@@ -1,4 +1,4 @@
 (library
  (name Interpreter)
- (libraries bwd algaeff bantorra yuujinchou algaett.nbe algaett.elaborator)
+ (libraries bwd algaeff bantorra yuujinchou algaett.synclazy algaett.nbe algaett.elaborator)
  (public_name algaett.interpreter))

--- a/src/nbe/Conversion.ml
+++ b/src/nbe/Conversion.ml
@@ -4,7 +4,7 @@ module D = Domain
 
 let rec force_all =
   function
-  | D.Unfold (_, _, v) -> force_all (Lazy.force v)
+  | D.Unfold (_, _, v) -> force_all (SyncLazy.force v)
   | v -> v
 
 type env =
@@ -97,13 +97,13 @@ let rec equate v1 dir v2 =
            According to Andras, using `Rigid here will probably make the elaborator too optimistic,
            backtracking too many times, but this claim has not been carefully verified against
            "real" codebase. *)
-        with_mode `Full @@ fun () -> equate (Lazy.force v1) dir (Lazy.force v2)
+        with_mode `Full @@ fun () -> equate (SyncLazy.force v1) dir (SyncLazy.force v2)
     else
-      equate (Lazy.force v1) dir (Lazy.force v2)
+      equate (SyncLazy.force v1) dir (SyncLazy.force v2)
   | D.Unfold (_, _, v1), dir, v2, `Rigid ->
-    equate (Lazy.force v1) dir v2
+    equate (SyncLazy.force v1) dir v2
   | v1, dir, D.Unfold (_, _, v2), `Rigid ->
-    equate v1 dir (Lazy.force v2)
+    equate v1 dir (SyncLazy.force v2)
   | D.Unfold _, _, _, `Full | _, _, D.Unfold _, `Full ->
     failwith "imposseble: force did not unfold all Domain.Unfold"
 

--- a/src/nbe/Data.ml
+++ b/src/nbe/Data.ml
@@ -8,7 +8,7 @@ type global = Bantorra.Manager.path * int
 type syn =
   | Var of int
   | Axiom of Yuujinchou.Trie.path
-  | Def of Yuujinchou.Trie.path * value Lazy.t
+  | Def of Yuujinchou.Trie.path * value SyncLazy.t
   | Pi of syn * (* binding *) syn
   | Lam of (* binding *) syn
   | App of syn * syn
@@ -22,7 +22,7 @@ type syn =
   | ULvl of (ULvlShift.t, syn) Mugen.Syntax.endo
   | VirUniv
 
-and env = value Lazy.t bwd (* invariant: lazy values must be effect-less *)
+and env = value SyncLazy.t bwd (* invariant: lazy values must be effect-less *)
 
 and closure = Clo of {body : syn; env : env}
 
@@ -41,14 +41,14 @@ and value =
 
 and cut = cut_head * frame bwd
 
-and unfold = unfold_head * frame bwd * value Lazy.t (* invariant: lazy values must be effect-less *)
+and unfold = unfold_head * frame bwd * value SyncLazy.t (* invariant: lazy values must be effect-less *)
 
 and cut_head =
   | Lvl of int
   | Axiom of Yuujinchou.Trie.path
 
 and unfold_head =
-  | Def of Yuujinchou.Trie.path * value Lazy.t
+  | Def of Yuujinchou.Trie.path * value SyncLazy.t
 
 and frame =
   | App of value

--- a/src/nbe/Domain.ml
+++ b/src/nbe/Domain.ml
@@ -2,7 +2,7 @@ open Bwd
 
 module S = Syntax
 
-type env = Data.value Lazy.t bwd (* invariant: lazy values must be effect-less *)
+type env = Data.value SyncLazy.t bwd (* invariant: lazy values must be effect-less *)
 
 type closure = Data.closure = Clo of {body : S.t; env : env}
 
@@ -28,7 +28,7 @@ type cut_head = Data.cut_head =
   | Axiom of Yuujinchou.Trie.path (* not used for now *)
 
 type unfold_head = Data.unfold_head =
-  | Def of Yuujinchou.Trie.path * con Lazy.t
+  | Def of Yuujinchou.Trie.path * con SyncLazy.t
 
 type frame = Data.frame =
   | App of con

--- a/src/nbe/NbE.mli
+++ b/src/nbe/NbE.mli
@@ -3,7 +3,7 @@ module Domain : module type of Domain
 module ULvl : module type of ULvl
 module LHS : module type of LHS
 
-val inst_clo : Domain.closure -> Domain.t Lazy.t -> Domain.t
+val inst_clo : Domain.closure -> Domain.t SyncLazy.t -> Domain.t
 val inst_clo' : Domain.closure -> Domain.t -> Domain.t
 val app_ulvl : tp:Domain.t -> ulvl:Domain.t -> Domain.t
 

--- a/src/nbe/Semantics.ml
+++ b/src/nbe/Semantics.ml
@@ -17,7 +17,7 @@ struct
     let env = env #< arg in
     Eff.run ~env @@ fun () -> eval body
 
-  and inst_clo' clo arg = inst_clo clo @@ Lazy.from_val arg
+  and inst_clo' clo arg = inst_clo clo @@ SyncLazy.from_val arg
 
   and app v0 v1 =
     match v0 with
@@ -25,7 +25,7 @@ struct
     | D.Cut (hd, frms) ->
       D.Cut (hd, frms #< (D.App v1))
     | D.Unfold (hd, frms, v0) ->
-      D.Unfold (hd, frms #< (D.App v1), Lazy.map (fun v0 -> app v0 v1) v0)
+      D.Unfold (hd, frms #< (D.App v1), SyncLazy.map (fun v0 -> app v0 v1) v0)
     | _ -> invalid_arg "Evaluation.app"
 
   and fst : D.t -> D.t =
@@ -34,7 +34,7 @@ struct
     | D.Cut (hd, frms) ->
       D.Cut (hd, frms #< D.Fst)
     | D.Unfold (hd, frms, v0) ->
-      D.Unfold (hd, frms #< D.Fst, Lazy.map fst v0)
+      D.Unfold (hd, frms #< D.Fst, SyncLazy.map fst v0)
     | _ -> invalid_arg "Evaluation.fst"
 
   and snd : D.t -> D.t =
@@ -43,7 +43,7 @@ struct
     | D.Cut (hd, frms) ->
       D.Cut (hd, frms #< D.Snd)
     | D.Unfold (hd, frms, v0) ->
-      D.Unfold (hd, frms #< D.Snd, Lazy.map snd v0)
+      D.Unfold (hd, frms #< D.Snd, SyncLazy.map snd v0)
     | _ -> invalid_arg "Evaluation.snd"
 
   and eval_ulvl =
@@ -54,7 +54,7 @@ struct
 
   and eval : S.t -> D.t =
     function
-    | S.Var idx -> Lazy.force (of_idx idx)
+    | S.Var idx -> SyncLazy.force (of_idx idx)
     | S.Axiom p -> D.Cut (D.Axiom p, Emp)
     | S.Def (p, v) -> D.def p v
     | S.Pi (base, (* binding *) fam) -> D.Pi (eval base, make_clo fam)

--- a/src/nbe/Semantics.mli
+++ b/src/nbe/Semantics.mli
@@ -1,4 +1,4 @@
-val inst_clo : Domain.closure -> Domain.t Lazy.t -> Domain.t
+val inst_clo : Domain.closure -> Domain.t SyncLazy.t -> Domain.t
 val inst_clo' : Domain.closure -> Domain.t -> Domain.t
 val eval : env:Domain.env -> Syntax.t -> Domain.t
 val eval_top : Syntax.t -> Domain.t

--- a/src/nbe/Syntax.ml
+++ b/src/nbe/Syntax.ml
@@ -1,7 +1,7 @@
 type t = Data.syn =
   | Var of int
   | Axiom of Yuujinchou.Trie.path
-  | Def of Yuujinchou.Trie.path * Data.value Lazy.t
+  | Def of Yuujinchou.Trie.path * Data.value SyncLazy.t
   | Pi of t * (* binding *) t
   | Lam of (* binding *) t
   | App of t * t

--- a/src/nbe/ULvl.ml
+++ b/src/nbe/ULvl.ml
@@ -13,7 +13,7 @@ let rec of_con =
   function
   | Domain.Cut (Lvl i, Emp) -> var i
   | Domain.ULvl endo -> of_endo endo
-  | Domain.Unfold (_, _, v) -> of_con (Lazy.force v)
+  | Domain.Unfold (_, _, v) -> of_con (SyncLazy.force v)
   | _ -> invalid_arg "of_con"
 
 and of_endo =

--- a/src/nbe/dune
+++ b/src/nbe/dune
@@ -1,4 +1,4 @@
 (library
  (name NbE)
- (libraries bwd algaeff bantorra mugen yuujinchou)
+ (libraries bwd algaeff bantorra mugen yuujinchou algaett.synclazy)
  (public_name algaett.nbe))

--- a/src/refiner/Eff.mli
+++ b/src/refiner/Eff.mli
@@ -20,7 +20,7 @@ val resolve_level : int -> NbE.Domain.cell option
 (** invariant: the return values must be effect-less *)
 val eval : NbE.Syntax.t -> NbE.Domain.t
 
-val lazy_eval : NbE.Syntax.t -> NbE.Domain.t Lazy.t
+val lazy_eval : NbE.Syntax.t -> NbE.Domain.t SyncLazy.t
 val equate : NbE.Domain.t -> [ `EQ | `GE | `LE ] -> NbE.Domain.t -> unit
 
 val quote : NbE.Domain.t -> NbE.Syntax.t

--- a/src/refiner/ResolveData.ml
+++ b/src/refiner/ResolveData.ml
@@ -1,3 +1,3 @@
 type t =
   | Axiom of {tp : NbE.Domain.t}
-  | Def of {tm : NbE.Domain.t Lazy.t; tp : NbE.Domain.t}
+  | Def of {tm : NbE.Domain.t SyncLazy.t; tp : NbE.Domain.t}

--- a/src/refiner/dune
+++ b/src/refiner/dune
@@ -2,7 +2,7 @@
  (name Refiner)
  (flags
   (:standard -w -32-37-38-27-26-79-39 -warn-error -a+31))
- (libraries bwd algaeff mugen yuujinchou algaett.nbe)
+ (libraries bwd algaeff mugen yuujinchou algaett.synclazy algaett.nbe)
  (public_name algaett.refiner))
 
 (include_subdirs unqualified)

--- a/src/synclazy/SyncLazy.ml
+++ b/src/synclazy/SyncLazy.ml
@@ -1,0 +1,14 @@
+type 'a t = 'a Lazy.t * Mutex.t
+
+let[@inline] from_lazy v = v, Mutex.create ()
+let[@inline] from_val v = from_lazy (Lazy.from_val v)
+
+let force (v, m) =
+  Mutex.lock m;
+  Fun.protect ~finally:(fun () -> Mutex.unlock m) @@ fun () ->
+  Lazy.force v
+
+let map f (v, m) =
+  Mutex.lock m;
+  Fun.protect ~finally:(fun () -> Mutex.unlock m) @@ fun () ->
+  Lazy.map f v, m

--- a/src/synclazy/SyncLazy.mli
+++ b/src/synclazy/SyncLazy.mli
@@ -1,0 +1,5 @@
+type !+'a t
+val from_lazy : 'a Lazy.t -> 'a t
+val from_val : 'a -> 'a t
+val force : 'a t -> 'a
+val map : ('a -> 'b) -> 'a t -> 'b t

--- a/src/synclazy/dune
+++ b/src/synclazy/dune
@@ -1,0 +1,3 @@
+(library
+ (name SyncLazy)
+ (public_name algaett.synclazy))


### PR DESCRIPTION
Lazy expressions/values are not thread-safe (see https://github.com/ocaml-multicore/ocaml-multicore/issues/750). This PR introduces a slow but safe version with mutexes. An alternative is busy waiting + `Domain.cpu_relax`.