### PR TITLE
feat: 🛐 Worship asai 2.0

### DIFF
--- a/algaett.opam
+++ b/algaett.opam
@@ -20,11 +20,13 @@ depends: [
   "odoc" {with-doc}
   "bantorra"
   "mugen"
+  "asai"
 ]
 pin-depends: [
   [ "bantorra.0.2.0~dev" "git+https://github.com/RedPRL/bantorra" ]
   [ "emoji.1.2.0~pre" "git+https://github.com/fxfactorial/ocaml-emoji" ]
   [ "mugen.0.1.0~dev" "git+https://github.com/RedPRL/mugen" ]
+  [ "asai.~dev" "git+https://github.com/RedPRL/asai"]
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/src/bin/Main.ml
+++ b/src/bin/Main.ml
@@ -1,3 +1,3 @@
 let () = Printexc.record_backtrace true
 
-let () = Loader.load (`File Sys.argv.(1))
+let () = Loader.load (`File Sys.argv.(1)) (if Array.length Sys.argv > 2 then Some Sys.argv.(2) else None)

--- a/src/elaborator/Eff.ml
+++ b/src/elaborator/Eff.ml
@@ -32,5 +32,3 @@ end
 
 include Perform
 
-let not_inferable ~tm:Asai.Span.{value; loc} =
-  Error.Logger.fatalf ?loc ~code:NotInferable "Could not infer a type for this term"

--- a/src/elaborator/Eff.ml
+++ b/src/elaborator/Eff.ml
@@ -2,8 +2,6 @@ module CS = Syntax
 module D = NbE.Domain
 module R = Refiner
 
-exception Error of Errors.t
-
 type _ Effect.t += Unleash : CS.bound_name * R.ResolveData.t -> CS.name Effect.t
 
 module type Handler =
@@ -34,5 +32,5 @@ end
 
 include Perform
 
-let not_inferable ~tm = raise @@ Error (NotInferable {tm})
-let ill_typed ~tm ~tp = raise @@ Error (IllTyped {tm; tp})
+let not_inferable ~tm:Asai.Span.{value; loc} =
+  Error.Logger.fatalf ?loc ~code:NotInferable "Could not infer a type for this term"

--- a/src/elaborator/Eff.mli
+++ b/src/elaborator/Eff.mli
@@ -12,7 +12,4 @@ end
 module Perform : Handler
 include module type of Perform
 
-exception Error of Errors.t
-
 val not_inferable : tm:Syntax.t -> 'a
-val ill_typed : tm:Syntax.t -> tp:NbE.Domain.t -> 'a

--- a/src/elaborator/Eff.mli
+++ b/src/elaborator/Eff.mli
@@ -12,4 +12,3 @@ end
 module Perform : Handler
 include module type of Perform
 
-val not_inferable : tm:Syntax.t -> 'a

--- a/src/elaborator/Elaborator.ml
+++ b/src/elaborator/Elaborator.ml
@@ -49,12 +49,12 @@ let infer_var p s : T.infer =
     R.Structural.local_var cell
   | Some _, Some _ ->
     Format.eprintf "@[<2>Local@ variable@ %a@ could@ not@ have@ level@ shifting@]@." Syntax.dump_name p;
-    Eff.not_inferable ~tm:{node = CS.Var (p, s); loc = None}
+    Eff.not_inferable ~tm:{value = CS.Var (p, s); loc = None}
   | None, _ ->
     R.Structural.global_var p (check_shift s)
 
 let rec infer tm : T.infer =
-  match tm.CS.node with
+  match tm.Asai.Span.value with
   | CS.Var (p, s) ->
     infer_var p s
   | CS.Ann {tm; tp} ->
@@ -70,7 +70,7 @@ let rec infer tm : T.infer =
     Eff.not_inferable ~tm
 
 and check tm : T.check =
-  match tm.CS.node with
+  match tm.Asai.Span.value with
   | CS.Pi (base, name, fam) ->
     R.Pi.pi ~name ~cbase:(check base) ~cfam:(fun _ -> check fam)
   | CS.VirPi (base, name, fam) ->

--- a/src/elaborator/Elaborator.ml
+++ b/src/elaborator/Elaborator.ml
@@ -67,7 +67,7 @@ let rec infer tm : T.infer =
   | CS.Snd tm ->
     R.Sigma.snd ~itm:(infer tm)
   | _ ->
-    Eff.not_inferable ~tm
+    Error.Logger.fatalf ?loc:tm.loc ~code:NotInferable "Could not infer a type for this term"
 
 and check tm : T.check =
   let open Asai.Span in

--- a/src/elaborator/Elaborator.ml
+++ b/src/elaborator/Elaborator.ml
@@ -47,8 +47,7 @@ let infer_var p s : T.infer =
   | Some (cell, ()), None ->
     R.Structural.local_var cell
   | Some _, Some _ ->
-    Format.eprintf "@[<2>Local@ variable@ %a@ could@ not@ have@ level@ shifting@]@." Syntax.dump_name p;
-    Eff.not_inferable ~tm:{value = CS.Var (p, s); loc = None}
+    Error.Logger.fatalf ?loc:(R.Eff.loc ()) ~code:NotInferable "@[<2>Local@ variable@ '%a'@ could@ not@ have@ level@ shifting@]@." Syntax.dump_name p
   | None, _ ->
     R.Structural.global_var p (check_shift s)
 

--- a/src/elaborator/Elaborator.ml
+++ b/src/elaborator/Elaborator.ml
@@ -54,7 +54,7 @@ let infer_var p s : T.infer =
 let rec infer tm : T.infer =
   let open Asai.Span in
   T.Infer.locate ~loc:tm.loc @@
-  T.Infer.trace ?loc:tm.loc "While inferring" @@
+  T.Infer.trace ?loc:tm.loc (Format.dprintf "While inferring") @@
   match tm.value with
   | CS.Var (p, s) ->
     infer_var p s
@@ -73,7 +73,7 @@ and check tm : T.check =
   let open Asai.Span in
   T.Check.locate ~loc:tm.loc @@
   T.Check.peek @@ fun goal ->
-  T.Check.trace ?loc:tm.loc (Format.asprintf "While checking against %a" S.dump (R.Eff.quote goal.tp)) @@
+  T.Check.trace ?loc:tm.loc (Format.dprintf "While checking against %a" S.dump (R.Eff.quote goal.tp)) @@
   match tm.value with
   | CS.Pi (base, name, fam) ->
     R.Pi.pi ~name ~cbase:(check base) ~cfam:(fun _ -> check fam)

--- a/src/elaborator/Elaborator.mli
+++ b/src/elaborator/Elaborator.mli
@@ -1,7 +1,6 @@
 module Syntax : module type of Syntax
-module Errors : module type of Errors
 module Eff : module type of Eff
 
-val infer_top : NbE.LHS.t -> Syntax.t -> (NbE.Syntax.t * NbE.Domain.t, Errors.t) result
-val check_tp_top : NbE.LHS.t -> Syntax.t -> (NbE.Syntax.t, Errors.t) result
-val check_top : NbE.LHS.t -> Syntax.t -> tp:NbE.Domain.t -> (NbE.Syntax.t, Errors.t) result
+val infer_top : NbE.LHS.t -> Syntax.t -> NbE.Syntax.t * NbE.Domain.t
+val check_tp_top : NbE.LHS.t -> Syntax.t -> NbE.Syntax.t
+val check_top : NbE.LHS.t -> Syntax.t -> tp:NbE.Domain.t -> NbE.Syntax.t

--- a/src/elaborator/Errors.ml
+++ b/src/elaborator/Errors.ml
@@ -1,4 +1,0 @@
-type t =
-  | NotInferable of {tm : Syntax.t}
-  | IllTyped of {tm : Syntax.t; tp : NbE.Domain.t}
-  | Conversion of NbE.Domain.t * NbE.Domain.t

--- a/src/elaborator/Syntax.ml
+++ b/src/elaborator/Syntax.ml
@@ -1,21 +1,3 @@
-type span =
-  {start : Lexing.position;
-   stop : Lexing.position}
-
-let dump_position fmt Lexing.{pos_fname; pos_lnum; pos_bol; pos_cnum} =
-  Format.fprintf fmt "@[<2>{ pos_fname = \"%s\";@ pos_lnum = %i;@ pos_bol = %i;@ pos_cnum = %i; }@]"
-    (String.escaped pos_fname) pos_lnum pos_bol pos_cnum
-
-let dump_span fmt {start; stop} =
-  Format.fprintf fmt "@[<2>{ start = @[%a@];@ stop = @[%a@]; }@]" dump_position start dump_position stop
-
-type 'a node = {node : 'a; loc : span option}
-
-let dump_node dump fmt {node; loc} =
-  match loc with
-  | None -> dump fmt node
-  | Some loc ->
-    Format.fprintf fmt "@[<2>{ node = @[%a@];@ loc = @[%a@]; }@]" dump node dump_span loc
 
 type name = Yuujinchou.Trie.path
 
@@ -37,7 +19,7 @@ let dump_shift fmt =
   function
   | Translate i -> Format.fprintf fmt "+%i" i
 
-type t = t_ node
+type t = t_ Asai.Span.located
 and t_ =
   | Ann of {tm : t; tp : t}
   | Var of name * shift list option
@@ -56,8 +38,8 @@ let dump_shifts fmt ss =
   Format.fprintf fmt "@[%a@]"
     (Format.pp_print_list ~pp_sep:(fun fmt () -> Format.pp_print_string fmt ";") dump_shift) ss
 
-let rec dump fmt =
-  dump_node dump_ fmt
+let rec dump fmt Asai.Span.{value ; loc = _}=
+  dump_ fmt value
 
 and dump_ fmt =
   function

--- a/src/elaborator/dune
+++ b/src/elaborator/dune
@@ -2,5 +2,5 @@
  (name Elaborator)
  (flags
   (:standard -w -32-37-38-27-26-79-39 -warn-error -a+31))
- (libraries bwd algaeff mugen yuujinchou algaett.nbe algaett.refiner asai)
+ (libraries bwd algaeff mugen yuujinchou asai algaett.nbe algaett.refiner algaett.error)
  (public_name algaett.elaborator))

--- a/src/elaborator/dune
+++ b/src/elaborator/dune
@@ -2,5 +2,5 @@
  (name Elaborator)
  (flags
   (:standard -w -32-37-38-27-26-79-39 -warn-error -a+31))
- (libraries bwd algaeff mugen yuujinchou algaett.nbe algaett.refiner)
+ (libraries bwd algaeff mugen yuujinchou algaett.nbe algaett.refiner asai)
  (public_name algaett.elaborator))

--- a/src/error/Connective.ml
+++ b/src/error/Connective.ml
@@ -1,0 +1,22 @@
+type t =
+  [ `Pi
+  | `VirPi
+  | `Sigma
+  | `Univ
+  | `VirUniv
+  | `TpULvl
+  ]
+
+let dump_conn fmt : t -> _ = function
+  | `Pi -> Format.fprintf fmt "Pi"
+  | `VirPi -> Format.fprintf fmt "Virtual Pi"
+  | `Sigma -> Format.fprintf fmt "Sigma"
+  | `Univ -> Format.fprintf fmt "Univ"
+  | `VirUniv -> Format.fprintf fmt "Virtual Univ"
+  | `TpULvl -> Format.fprintf fmt "TpULvl"
+
+let check ?loc conn fmt x =
+  Logger.fatalf ?loc ~code:IllTyped "Trying to construct an element of a %a type but you are checking against %a" dump_conn conn fmt x
+
+let infer ?loc conn fmt x =
+  Logger.fatalf ?loc ~code:IllTyped "Trying to eliminate an element of a %a type but you have an element of %a" dump_conn conn fmt x

--- a/src/error/Logger.ml
+++ b/src/error/Logger.ml
@@ -1,0 +1,27 @@
+type code =
+  | NotInScope
+  | NotInferable
+  | IllTyped
+  | Conversion
+
+module Code : Asai.Code.S with type t = code =
+struct
+  type t = code
+  let default_severity = let open Asai.Severity in function
+    | NotInScope -> Error
+    | NotInferable -> Error
+    | IllTyped -> Error
+    | Conversion -> Error
+
+  let to_string = function
+    | NotInScope -> 
+      "We encountered an out of scope variable"
+    | NotInferable ->
+      "We encountered a term for which we could not infer a type"
+    | IllTyped ->
+      "We encountered an ill typed term"
+    | Conversion ->
+      "We expected two terms to be convertible but they are not"
+end
+
+include Asai.Logger.Make(Code)

--- a/src/error/Logger.ml
+++ b/src/error/Logger.ml
@@ -8,10 +8,10 @@ module Code : Asai.Code.S with type t = code =
 struct
   type t = code
   let default_severity = let open Asai.Severity in function
-    | NotInScope -> Error
-    | NotInferable -> Error
-    | IllTyped -> Error
-    | Conversion -> Error
+      | NotInScope -> Error
+      | NotInferable -> Error
+      | IllTyped -> Error
+      | Conversion -> Error
 
   let to_string = function
     | NotInScope -> 

--- a/src/error/dune
+++ b/src/error/dune
@@ -1,0 +1,4 @@
+(library
+ (name Error)
+ (libraries asai.unix)
+ (public_name algaett.error))

--- a/src/interpreter/Driver.ml
+++ b/src/interpreter/Driver.ml
@@ -8,7 +8,7 @@ let include_singleton ?loc name data =
   | None -> ()
   | Some p -> UE.include_singleton ?loc (p, data)
 
-let rec execute_decl {CS.node = decl; CS.loc = loc} =
+let rec execute_decl {Asai.Span.value = decl; Asai.Span.loc} =
   match decl with
   | CS.Axiom {name; tp} ->
     let tp = NbE.eval_top @@ UE.reraise_elaborator @@ Elaborator.check_tp_top NbE.LHS.unknown tp in
@@ -24,7 +24,7 @@ let rec execute_decl {CS.node = decl; CS.loc = loc} =
   | CS.Quit -> raise Quit
 
 and execute_section sec =
-  List.iter execute_decl sec.CS.node
+  List.iter execute_decl sec.Asai.Span.value
 
 let execute prog =
   UnitEffect.trap @@ fun () -> try execute_section prog with Quit -> ()

--- a/src/interpreter/Driver.ml
+++ b/src/interpreter/Driver.ml
@@ -11,11 +11,11 @@ let include_singleton ?loc name data =
 let rec execute_decl {Asai.Span.value = decl; Asai.Span.loc} =
   match decl with
   | CS.Axiom {name; tp} ->
-    let tp = NbE.eval_top @@ UE.reraise_elaborator @@ Elaborator.check_tp_top NbE.LHS.unknown tp in
+    let tp = NbE.eval_top @@ Elaborator.check_tp_top NbE.LHS.unknown tp in
     include_singleton ?loc (name : CS.bound_name) @@ Axiom {tp}
   | CS.Def {name; tm} ->
     let lhs = Option.fold ~none:NbE.LHS.unknown ~some:NbE.LHS.head name in
-    let tm, tp = UE.reraise_elaborator @@ Elaborator.infer_top lhs tm in
+    let tm, tp = Elaborator.infer_top lhs tm in
     include_singleton ?loc name @@ Def {tm = SyncLazy.from_lazy @@ lazy begin NbE.eval_top tm end; tp}
   | CS.Import {unit_path; modifier} ->
     UE.import ?loc unit_path modifier
@@ -27,4 +27,4 @@ and execute_section sec =
   List.iter execute_decl sec.Asai.Span.value
 
 let execute prog =
-  UnitEffect.trap @@ fun () -> try execute_section prog with Quit -> ()
+  try execute_section prog with Quit -> ()

--- a/src/interpreter/Driver.mli
+++ b/src/interpreter/Driver.mli
@@ -1,1 +1,1 @@
-val execute : Syntax.prog -> (unit, UnitEffect.error) result
+val execute : Syntax.prog -> unit

--- a/src/interpreter/Interpreter.ml
+++ b/src/interpreter/Interpreter.ml
@@ -9,8 +9,8 @@ type error = UnitEffect.error =
 let execute = Driver.execute
 
 type unused_info = Used.info =
-  | Imported of Bantorra.Manager.path Elaborator.Syntax.node
-  | Local of Yuujinchou.Trie.path Elaborator.Syntax.node
+  | Imported of Bantorra.Manager.path Asai.Span.located
+  | Local of Yuujinchou.Trie.path Asai.Span.located
 
 module type Handler = UnitEffect.Handler
 module Run = UnitEffect.Run

--- a/src/interpreter/Interpreter.ml
+++ b/src/interpreter/Interpreter.ml
@@ -1,11 +1,5 @@
 module Syntax = Syntax
 
-type error = UnitEffect.error =
-  | NotInScope of Yuujinchou.Trie.path
-  | NotInferable of {tm : Syntax.t}
-  | IllTyped of {tm : Syntax.t; tp : NbE.Domain.t}
-  | Conversion of NbE.Domain.t * NbE.Domain.t
-
 let execute = Driver.execute
 
 type unused_info = Used.info =

--- a/src/interpreter/Interpreter.mli
+++ b/src/interpreter/Interpreter.mli
@@ -9,8 +9,8 @@ type error =
 val execute : Syntax.prog -> (unit, error) result
 
 type unused_info =
-  | Imported of Bantorra.Manager.path Elaborator.Syntax.node
-  | Local of Yuujinchou.Trie.path Elaborator.Syntax.node
+  | Imported of Bantorra.Manager.path Asai.Span.located
+  | Local of Yuujinchou.Trie.path Asai.Span.located
 
 module type Handler = UnitEffect.Handler
 module Perform : Handler

--- a/src/interpreter/Interpreter.mli
+++ b/src/interpreter/Interpreter.mli
@@ -1,12 +1,6 @@
 module Syntax : module type of Syntax
 
-type error =
-  | NotInScope of Yuujinchou.Trie.path
-  | NotInferable of {tm : Syntax.t}
-  | IllTyped of {tm : Syntax.t; tp : NbE.Domain.t}
-  | Conversion of NbE.Domain.t * NbE.Domain.t
-
-val execute : Syntax.prog -> (unit, error) result
+val execute : Syntax.prog -> unit
 
 type unused_info =
   | Imported of Bantorra.Manager.path Asai.Span.located

--- a/src/interpreter/Syntax.ml
+++ b/src/interpreter/Syntax.ml
@@ -3,7 +3,7 @@ include Elaborator.Syntax
 type empty = |
 type modifier = empty Yuujinchou.Language.t
 
-type cmd = cmd_ node
+type cmd = cmd_ Asai.Span.located
 and cmd_ =
   | Axiom of {name : bound_name; tp : t}
   | Def of {name : bound_name; tm : t}
@@ -11,7 +11,7 @@ and cmd_ =
   | Section of {prefix : Yuujinchou.Trie.path; block : section}
   | Quit
 
-and section = section_ node
+and section = section_ Asai.Span.located
 and section_ = cmd list
 
 type prog = section

--- a/src/interpreter/UnitEffect.ml
+++ b/src/interpreter/UnitEffect.ml
@@ -53,7 +53,7 @@ module S =
 
 
 let include_singleton ?loc (p, data) =
-  let id = Used.new_ (Used.Local {node = p; loc}) in
+  let id = Used.new_ (Used.Local {value = p; loc}) in
   S.include_singleton (p, (data, id))
 
 let section p =
@@ -64,7 +64,7 @@ let get_export () =
   S.get_export ()
 
 let import ?loc u m =
-  let id = Used.new_ (Imported {node = u; loc}) in
+  let id = Used.new_ (Imported {value = u; loc}) in
   let u = S.modify m @@ Yuujinchou.Trie.retag id @@ load u in
   S.import_subtree ([], u)
 

--- a/src/interpreter/UnitEffect.ml
+++ b/src/interpreter/UnitEffect.ml
@@ -59,11 +59,10 @@ struct
   struct
     let counter = ref 0
 
-    let resolve Asai.Span.{value = p ; loc} =
+    let resolve p =
       match S.resolve p with
-      | None -> 
-        Error.Logger.fatalf ?loc ~code:NotInScope "The variable '%a' is not in scope" Elaborator.Syntax.dump_name p
-      | Some (data, tag) -> Used.use tag; data
+      | None -> None
+      | Some (data, tag) -> Used.use tag; Some data
 
     let unleash (name : Syntax.bound_name) data =
       let p =

--- a/src/interpreter/UnitEffect.mli
+++ b/src/interpreter/UnitEffect.mli
@@ -1,12 +1,3 @@
-type error =
-  | NotInScope of Yuujinchou.Trie.path
-  | NotInferable of {tm: Syntax.t}
-  | IllTyped of {tm: Syntax.t; tp: NbE.Domain.t}
-  | Conversion of NbE.Domain.t * NbE.Domain.t
-
-val reraise_elaborator : ('a, Elaborator.Errors.t) result -> 'a
-val trap : (unit -> 'a) -> ('a, error) result
-
 val include_singleton : ?loc:Asai.Span.t -> (Yuujinchou.Trie.path * Refiner.ResolveData.t) -> unit
 val import : ?loc:Asai.Span.t -> Bantorra.Manager.path -> Syntax.modifier -> unit
 val section : Yuujinchou.Trie.path -> (unit -> 'a) -> 'a

--- a/src/interpreter/UnitEffect.mli
+++ b/src/interpreter/UnitEffect.mli
@@ -7,8 +7,8 @@ type error =
 val reraise_elaborator : ('a, Elaborator.Errors.t) result -> 'a
 val trap : (unit -> 'a) -> ('a, error) result
 
-val include_singleton : ?loc:Elaborator.Syntax.span -> (Yuujinchou.Trie.path * Refiner.ResolveData.t) -> unit
-val import : ?loc:Elaborator.Syntax.span -> Bantorra.Manager.path -> Syntax.modifier -> unit
+val include_singleton : ?loc:Asai.Span.t -> (Yuujinchou.Trie.path * Refiner.ResolveData.t) -> unit
+val import : ?loc:Asai.Span.t -> Bantorra.Manager.path -> Syntax.modifier -> unit
 val section : Yuujinchou.Trie.path -> (unit -> 'a) -> 'a
 val get_export : unit -> Refiner.ResolveData.t Yuujinchou.Trie.Untagged.t
 

--- a/src/interpreter/Used.ml
+++ b/src/interpreter/Used.ml
@@ -1,6 +1,6 @@
 type info =
-  | Imported of Bantorra.Manager.path Elaborator.Syntax.node
-  | Local of Yuujinchou.Trie.path Elaborator.Syntax.node
+  | Imported of Bantorra.Manager.path Asai.Span.located
+  | Local of Yuujinchou.Trie.path Asai.Span.located
 
 module Internal =
 struct

--- a/src/interpreter/Used.mli
+++ b/src/interpreter/Used.mli
@@ -1,6 +1,6 @@
 type info =
-  | Imported of Bantorra.Manager.path Elaborator.Syntax.node
-  | Local of Yuujinchou.Trie.path Elaborator.Syntax.node
+  | Imported of Bantorra.Manager.path Asai.Span.located
+  | Local of Yuujinchou.Trie.path Asai.Span.located
 
 type id
 val compare_id : id -> id -> int

--- a/src/interpreter/dune
+++ b/src/interpreter/dune
@@ -1,4 +1,4 @@
 (library
  (name Interpreter)
- (libraries bwd algaeff bantorra yuujinchou algaett.synclazy algaett.nbe algaett.elaborator)
+ (libraries bwd algaeff bantorra yuujinchou algaett.synclazy algaett.nbe algaett.elaborator algaett.error)
  (public_name algaett.interpreter))

--- a/src/loader/Loader.ml
+++ b/src/loader/Loader.ml
@@ -12,10 +12,17 @@ let run_interpreter =
 
 module Terminal = Asai_unix.Make(Error.Logger.Code)
 
-let load =
-  function
-  | `File filename ->
-    let prog = Parser.parse_file filename in
-    Error.Logger.run ~emit:Terminal.display ~fatal:Terminal.display @@ fun () ->
-    run_interpreter @@ fun () ->
-    Interpreter.execute prog
+let load input mode =
+  let display = match mode with
+    | Some ("--debug" | "-d") -> Terminal.display ~display_traces:true
+    | Some ("--interactive" | "-i") -> Terminal.interactive_trace
+    | Some _ -> failwith "unknown arg"
+    | None -> Terminal.display ~display_traces:false
+  in 
+  match input with
+    | `File filename ->
+      let prog = Parser.parse_file filename in
+      Error.Logger.run ~emit:display ~fatal:display @@ fun () ->
+      run_interpreter @@ fun () ->
+      Interpreter.execute prog
+

--- a/src/loader/Loader.ml
+++ b/src/loader/Loader.ml
@@ -10,9 +10,12 @@ module HandleInterpreter = Interpreter.Run (InterpreterHandler)
 let run_interpreter =
   HandleInterpreter.run
 
+module Terminal = Asai_unix.Make(Error.Logger.Code)
+
 let load =
   function
   | `File filename ->
     let prog = Parser.parse_file filename in
-    Result.get_ok @@ run_interpreter @@ fun () ->
+    Error.Logger.run ~emit:Terminal.display ~fatal:Terminal.display @@ fun () ->
+    run_interpreter @@ fun () ->
     Interpreter.execute prog

--- a/src/loader/Loader.ml
+++ b/src/loader/Loader.ml
@@ -20,9 +20,9 @@ let load input mode =
     | None -> Terminal.display ~display_traces:false
   in 
   match input with
-    | `File filename ->
-      let prog = Parser.parse_file filename in
-      Error.Logger.run ~emit:display ~fatal:display @@ fun () ->
-      run_interpreter @@ fun () ->
-      Interpreter.execute prog
+  | `File filename ->
+    let prog = Parser.parse_file filename in
+    Error.Logger.run ~emit:display ~fatal:display @@ fun () ->
+    run_interpreter @@ fun () ->
+    Interpreter.execute prog
 

--- a/src/loader/dune
+++ b/src/loader/dune
@@ -4,7 +4,9 @@
   bwd
   algaeff
   yuujinchou
+  asai.unix
   algaett.elaborator
   algaett.interpreter
-  algaett.parser)
+  algaett.parser
+  algaett.error)
  (public_name algaett.loader))

--- a/src/nbe/LHS.ml
+++ b/src/nbe/LHS.ml
@@ -1,5 +1,5 @@
 open Bwd
-open BwdNotation
+open Bwd.Infix
 
 type frame =
   | Ap of Domain.cell

--- a/src/nbe/Semantics.ml
+++ b/src/nbe/Semantics.ml
@@ -1,5 +1,5 @@
 open Bwd
-open BwdNotation
+open Bwd.Infix
 
 module S = Syntax
 module D = Domain

--- a/src/nbe/Syntax.ml
+++ b/src/nbe/Syntax.ml
@@ -39,3 +39,49 @@ module ULvl =
       let level l = ULvl l
       let unlevel = function ULvl l -> Some l | _ -> None
     end)
+
+let dump_name fmt n =
+  Format.fprintf fmt "@[%a@]"
+    (Format.pp_print_list ~pp_sep:(fun fmt () -> Format.pp_print_string fmt ".") Format.pp_print_string) n
+
+let dump_shift fmt i =
+  Format.fprintf fmt "%i" (Mugen.Shift.Int.to_int i)
+
+let rec dump fmt =
+  function
+  | Var ix ->
+    Format.fprintf fmt "Var @[%i@]" ix
+  | Lam tm ->
+    Format.fprintf fmt "@[<5>Lam (@[%a@])@]" dump tm
+  | App (tm1, tm2) ->
+    Format.fprintf fmt "@[<5>App (@[%a@],@ @[%a@])@]" dump tm1 dump tm2
+  | Pair (tm1, tm2) ->
+    Format.fprintf fmt "@[<6>Pair (@[%a@],@ @[%a@])@]" dump tm1 dump tm2
+  | Fst tm ->
+    Format.fprintf fmt "Fst @[%a@]" dump tm
+  | Snd tm ->
+    Format.fprintf fmt "Snd @[%a@]" dump tm
+  | Univ l ->
+    Format.fprintf fmt "Univ @[%a@]" dump l
+  | VirPi (base, fam) ->
+    Format.fprintf fmt "@[<7>VirPi (@[%a@],@ @[%a@])@]" dump base dump fam
+  | Pi (base, fam) ->
+    Format.fprintf fmt "@[<7>Pi (@[%a@],@ @[%a@])@]" dump base dump fam
+  | Sigma (base, fam) ->
+    Format.fprintf fmt "@[<7>Sigma (@[%a@],@ @[%a@])@]" dump base dump fam
+  | TpULvl ->
+    Format.fprintf fmt "TpULvl"
+  | VirUniv ->
+    Format.fprintf fmt "VirUniv"
+  | Axiom p ->
+    Format.fprintf fmt "Axiom %a" dump_name p
+  | Def (p, _) ->
+    Format.fprintf fmt "Def %a" dump_name p
+  | ULvl l ->
+    Format.fprintf fmt "ULvl %a" dump_endo l
+
+and dump_endo fmt =
+  Mugen.Syntax.Endo.dump
+    dump_shift
+    dump
+    fmt

--- a/src/parser/Cmd.ml
+++ b/src/parser/Cmd.ml
@@ -10,7 +10,7 @@ let parser section_ = cmd*
 and section = located section_
 and parser cmd_ =
   | def name:(Term.bound_name) colon tp:(Term.term) assign tm:(Term.term) ->
-      S.Def {name; tm = {node = S.Ann {tm; tp}; loc = None}}
+      S.Def {name; tm = {value = S.Ann {tm; tp}; loc = None}}
   | def name:(Term.bound_name) assign tm:(Term.term) ->
       S.Def {name; tm}
   | axiom name:(Term.bound_name) colon tp:(Term.term) ->

--- a/src/parser/Locate.ml
+++ b/src/parser/Locate.ml
@@ -10,14 +10,13 @@ let lexing_position i c =
   }
 
 let locate i1 c1 i2 c2 =
-  Elaborator.Syntax.{
-    start = lexing_position i1 c1;
-    stop = lexing_position i2 c2;
-  }
+  let open Asai.Span in
+  make (of_lex_position @@ lexing_position i1 c1)
+    (of_lex_position @@ lexing_position i2 c2)
 
 let located p =
-  p |> Earley.apply_position @@ fun i1 c1 i2 c2 x ->
-  Elaborator.Syntax.{
-    node = x;
+  p |> Earley.apply_position @@ fun i1 c1 i2 c2 value ->
+  Asai.Span.{
+    value;
     loc = Some (locate i1 c1 i2 c2);
   }

--- a/src/refiner/Eff.ml
+++ b/src/refiner/Eff.ml
@@ -104,10 +104,6 @@ let loc () =
 let locate ~loc k =
   Eff.scope (fun env -> {env with loc = loc}) k
 
-let not_convertible u v =
-  Error.Logger.fatalf ?loc:(loc ()) ~code:Conversion 
-    "Expected %a to be convertible with %a" S.dump (quote u) S.dump (quote v)
-
 module Generalize =
 struct
   type bnd = VirType of S.t | Type of S.t

--- a/src/refiner/Eff.ml
+++ b/src/refiner/Eff.ml
@@ -82,16 +82,16 @@ let bind ~name ~tp f =
   let cell = D.{tm = arg; tp} in
   let update env =
     { env with
-     size = env.size + 1;
-     locals = env.locals #< (SyncLazy.from_val cell);
-     local_names =
-       match name with
-       | None -> env.local_names
-       | Some name ->
-         Yuujinchou.Trie.update_singleton
-           name
-           (fun _ -> Some (cell, ()))
-           env.local_names}
+      size = env.size + 1;
+      locals = env.locals #< (SyncLazy.from_val cell);
+      local_names =
+        match name with
+        | None -> env.local_names
+        | Some name ->
+          Yuujinchou.Trie.update_singleton
+            name
+            (fun _ -> Some (cell, ()))
+            env.local_names}
   in
   Eff.scope update @@ fun () -> f cell
 
@@ -106,9 +106,9 @@ let locate ~loc k =
 
 let not_convertible u v =
   Error.Logger.fatalf ?loc:(loc ()) ~code:Conversion 
-  "Expected %a to be convertible with %a" S.dump (quote u) S.dump (quote v)
+    "Expected %a to be convertible with %a" S.dump (quote u) S.dump (quote v)
 
-  module Generalize =
+module Generalize =
 struct
   type bnd = VirType of S.t | Type of S.t
 

--- a/src/refiner/Eff.ml
+++ b/src/refiner/Eff.ml
@@ -5,11 +5,11 @@ module S = NbE.Syntax
 module D = NbE.Domain
 module UL = NbE.ULvl
 
-type _ Effect.t += Resolve : Yuujinchou.Trie.path Asai.Span.located -> ResolveData.t Effect.t
+type _ Effect.t += Resolve : Yuujinchou.Trie.path -> ResolveData.t option Effect.t
 
 module type Handler =
 sig
-  val resolve : Yuujinchou.Trie.path Asai.Span.located -> ResolveData.t
+  val resolve : Yuujinchou.Trie.path -> ResolveData.t option
 end
 
 module Run (H : Handler) =

--- a/src/refiner/Eff.mli
+++ b/src/refiner/Eff.mli
@@ -1,14 +1,14 @@
-exception Error of Errors.t
-
 val bind : name:Yuujinchou.Trie.path option -> tp:NbE.Domain.t -> (NbE.Domain.cell -> 'a) -> 'a
-
-val trap : (unit -> 'a) -> ('a, Errors.t) Result.t
 
 val blessed_ulvl : unit -> NbE.Domain.t
 
+val locate : loc:Asai.Span.t option -> (unit -> 'a) -> 'a
+
+val loc : unit -> Asai.Span.t option
+
 module type Handler =
 sig
-  val resolve : Yuujinchou.Trie.path -> ResolveData.t
+  val resolve : Yuujinchou.Trie.path Asai.Span.located -> ResolveData.t
 end
 
 module Perform : Handler

--- a/src/refiner/Eff.mli
+++ b/src/refiner/Eff.mli
@@ -25,8 +25,6 @@ val equate : NbE.Domain.t -> [ `EQ | `GE | `LE ] -> NbE.Domain.t -> unit
 
 val quote : NbE.Domain.t -> NbE.Syntax.t
 
-val not_convertible : NbE.Domain.t -> NbE.Domain.t -> 'a
-
 val with_top_env : (unit -> 'a) -> 'a
 
 module Generalize :

--- a/src/refiner/Eff.mli
+++ b/src/refiner/Eff.mli
@@ -8,7 +8,7 @@ val loc : unit -> Asai.Span.t option
 
 module type Handler =
 sig
-  val resolve : Yuujinchou.Trie.path Asai.Span.located -> ResolveData.t
+  val resolve : Yuujinchou.Trie.path -> ResolveData.t option
 end
 
 module Perform : Handler

--- a/src/refiner/Refiner.ml
+++ b/src/refiner/Refiner.ml
@@ -3,7 +3,6 @@ module D = NbE.Domain
 module UL = NbE.ULvl
 module LHS = NbE.LHS
 
-module Errors = Errors
 module ResolveData = ResolveData
 module Eff = Eff
 module Tactic = Tactic

--- a/src/refiner/Refiner.mli
+++ b/src/refiner/Refiner.mli
@@ -1,4 +1,3 @@
-module Errors : module type of Errors
 module Eff : module type of Eff
 module ResolveData : module type of ResolveData
 

--- a/src/refiner/Rule.ml
+++ b/src/refiner/Rule.ml
@@ -19,10 +19,10 @@ struct
     rule @@ fun goal ->
     Eff.locate ~loc @@ fun () ->
     run goal t
-    
+
   let trace ?loc msg t =
     rule @@ fun goal ->
-    Error.Logger.tracef ?loc "%s" msg @@ fun () ->
+    Error.Logger.tracef ?loc "%t" msg @@ fun () ->
     run goal t
 end
 
@@ -47,8 +47,8 @@ struct
     try Eff.equate tp' `LE goal.tp; tm' with
     | NbE.Unequal -> 
       Error.Logger.fatalf ?loc:(Eff.loc ()) ~code:Conversion 
-      "Expected %a to be convertible with %a" S.dump (Eff.quote tp') S.dump (Eff.quote goal.tp)
-    
+        "Expected %a to be convertible with %a" S.dump (Eff.quote tp') S.dump (Eff.quote goal.tp)
+
   let orelse t k : t =
     rule @@ fun goal ->
     try t goal with
@@ -59,10 +59,10 @@ struct
     rule @@ fun goal ->
     Eff.locate ~loc @@ fun () ->
     run goal t
-  
+
   let trace ?loc msg t =
     rule @@ fun goal ->
-    Error.Logger.tracef ?loc "%s" msg @@ fun () ->
+    Error.Logger.tracef ?loc "%t" msg @@ fun () ->
     run goal t
 end
 

--- a/src/refiner/Rule.ml
+++ b/src/refiner/Rule.ml
@@ -15,8 +15,14 @@ struct
   let rule t = t
   let run goal t = t goal
 
-  let locate ~loc t goal =
-    Eff.locate ~loc@@ fun () ->
+  let locate ~loc t =
+    rule @@ fun goal ->
+    Eff.locate ~loc @@ fun () ->
+    run goal t
+    
+  let trace ?loc msg t =
+    rule @@ fun goal ->
+    Error.Logger.tracef ?loc "%s" msg @@ fun () ->
     run goal t
 end
 
@@ -46,8 +52,15 @@ struct
     try t goal with
     | exn ->
       k exn goal
-  let locate ~loc t goal =
+
+  let locate ~loc t : t =
+    rule @@ fun goal ->
     Eff.locate ~loc @@ fun () ->
+    run goal t
+  
+  let trace ?loc msg t =
+    rule @@ fun goal ->
+    Error.Logger.tracef ?loc "%s" msg @@ fun () ->
     run goal t
 end
 

--- a/src/refiner/Rule.ml
+++ b/src/refiner/Rule.ml
@@ -14,6 +14,10 @@ struct
   type t = goal -> result
   let rule t = t
   let run goal t = t goal
+
+  let locate ~loc t goal =
+    Eff.locate ~loc@@ fun () ->
+    run goal t
 end
 
 type infer = Infer.t
@@ -42,6 +46,9 @@ struct
     try t goal with
     | exn ->
       k exn goal
+  let locate ~loc t goal =
+    Eff.locate ~loc @@ fun () ->
+    run goal t
 end
 
 type check = Check.t

--- a/src/refiner/Rule.ml
+++ b/src/refiner/Rule.ml
@@ -45,8 +45,10 @@ struct
     fun goal ->
     let tm', tp' = Infer.run Infer.{lhs = goal.lhs} inf in
     try Eff.equate tp' `LE goal.tp; tm' with
-    | NbE.Unequal -> Eff.not_convertible goal.tp tp'
-
+    | NbE.Unequal -> 
+      Error.Logger.fatalf ?loc:(Eff.loc ()) ~code:Conversion 
+      "Expected %a to be convertible with %a" S.dump (Eff.quote tp') S.dump (Eff.quote goal.tp)
+    
   let orelse t k : t =
     rule @@ fun goal ->
     try t goal with

--- a/src/refiner/Sigs.ml
+++ b/src/refiner/Sigs.ml
@@ -6,7 +6,7 @@ sig
   val run : goal -> t -> result
   val locate : loc:Asai.Span.t option -> t -> t
 
-  val trace : ?loc:Asai.Span.t -> string -> t -> t
+  val trace : ?loc:Asai.Span.t -> (Format.formatter -> unit) -> t -> t
 
 end
 
@@ -26,7 +26,7 @@ sig
 
   val locate : loc:Asai.Span.t option -> t -> t
 
-  val trace : ?loc:Asai.Span.t -> string -> t -> t
+  val trace : ?loc:Asai.Span.t -> (Format.formatter -> unit) -> t -> t
 end
 module type ShiftPublic =
 sig

--- a/src/refiner/Sigs.ml
+++ b/src/refiner/Sigs.ml
@@ -4,6 +4,8 @@ sig
   type goal = {lhs : NbE.LHS.t}
   type result = NbE.Syntax.t * NbE.Domain.t
   val run : goal -> t -> result
+  val locate : loc:Asai.Span.t option -> t -> t
+
 end
 
 module type CheckPublic =
@@ -19,6 +21,8 @@ sig
   val peek : (goal -> t) -> t
   val orelse : t -> (exn -> t) -> t
   val infer : infer -> t
+
+  val locate : loc:Asai.Span.t option -> t -> t
 end
 
 module type ShiftPublic =

--- a/src/refiner/Sigs.ml
+++ b/src/refiner/Sigs.ml
@@ -6,6 +6,8 @@ sig
   val run : goal -> t -> result
   val locate : loc:Asai.Span.t option -> t -> t
 
+  val trace : ?loc:Asai.Span.t -> string -> t -> t
+
 end
 
 module type CheckPublic =
@@ -23,8 +25,9 @@ sig
   val infer : infer -> t
 
   val locate : loc:Asai.Span.t option -> t -> t
-end
 
+  val trace : ?loc:Asai.Span.t -> string -> t -> t
+end
 module type ShiftPublic =
 sig
   type t

--- a/src/refiner/dune
+++ b/src/refiner/dune
@@ -2,7 +2,7 @@
  (name Refiner)
  (flags
   (:standard -w -32-37-38-27-26-79-39 -warn-error -a+31))
- (libraries bwd algaeff mugen yuujinchou algaett.synclazy algaett.nbe)
+ (libraries bwd algaeff mugen yuujinchou asai algaett.synclazy algaett.nbe algaett.error)
  (public_name algaett.refiner))
 
 (include_subdirs unqualified)

--- a/src/refiner/rules/Pi.ml
+++ b/src/refiner/rules/Pi.ml
@@ -13,8 +13,8 @@ let lam ~name ~cbnd : T.check =
     Eff.bind ~name ~tp:base @@ fun arg ->
     let fib = NbE.inst_clo' fam @@ arg.D.tm in
     S.lam @@ T.Check.run {tp = fib; lhs = LHS.app goal.lhs arg} @@ cbnd arg
-  | _ ->
-    invalid_arg "lam"
+  | tp ->
+    Error.Connective.check ?loc:(Eff.loc ()) `Pi S.dump (Eff.quote tp)
 
 let app ~itm ~ctm : T.infer =
   T.Infer.rule @@ fun _ ->
@@ -24,5 +24,5 @@ let app ~itm ~ctm : T.infer =
     let arg = T.Check.run {tp = base; lhs = LHS.unknown} ctm in
     let fib = NbE.inst_clo fam @@ Eff.lazy_eval arg in
     S.app fn arg, fib
-  | _ ->
-    invalid_arg "app"
+  | tp ->
+    Error.Connective.infer ?loc:(Eff.loc ()) `Pi S.dump (Eff.quote tp)

--- a/src/refiner/rules/Quantifier.ml
+++ b/src/refiner/rules/Quantifier.ml
@@ -18,8 +18,8 @@ let auxiliary ~name ~cbase ~cbase_sort ~cfam builder : T.check =
       T.Check.run {tp = goal.tp; lhs = LHS.unknown} @@ cfam x
     in
     builder base fam
-  | _ ->
-    invalid_arg "quantifier"
+  | tp ->
+    Error.Connective.check ?loc:(Eff.loc ()) `Univ S.dump (Eff.quote tp)
 
 
 let quantifier ~name ~cbase ~cfam builder : T.check =

--- a/src/refiner/rules/Sigma.ml
+++ b/src/refiner/rules/Sigma.ml
@@ -11,8 +11,8 @@ let pair ~cfst ~csnd : T.check =
     let tp2 = NbE.inst_clo fam @@ Eff.lazy_eval tm1 in
     let tm2 = T.Check.run {tp = tp2; lhs = LHS.snd goal.lhs} csnd in
     S.pair tm1 tm2
-  | _ ->
-    invalid_arg "pair"
+  | tp ->
+    Error.Connective.check ?loc:(Eff.loc ()) `Sigma S.dump (Eff.quote tp)
 
 let fst ~itm : T.infer =
   T.Infer.rule @@ fun _ ->
@@ -21,7 +21,7 @@ let fst ~itm : T.infer =
   | D.Sigma (base, _) ->
     S.fst tm, base
   | _ ->
-    invalid_arg "fst"
+    Error.Connective.infer ?loc:(Eff.loc ()) `Sigma S.dump (Eff.quote tp)
 
 let snd ~itm : T.infer =
   T.Infer.rule @@ fun _ ->
@@ -31,4 +31,4 @@ let snd ~itm : T.infer =
     let tp = NbE.inst_clo fam @@ Eff.lazy_eval @@ S.fst tm in
     S.snd tm, tp
   | _ ->
-    invalid_arg "snd"
+    Error.Connective.infer ?loc:(Eff.loc ()) `Sigma S.dump (Eff.quote tp)

--- a/src/refiner/rules/Structural.ml
+++ b/src/refiner/rules/Structural.ml
@@ -17,7 +17,7 @@ let global_var path shift : T.infer =
   T.Infer.rule @@ fun _ ->
   let ulvl = T.Shift.run shift in
   let tm, tp =
-    match Eff.resolve path with
+    match Eff.resolve {value = path ; loc = Eff.loc()} with
     | ResolveData.Axiom {tp} -> S.axiom path, tp
     | ResolveData.Def {tp; tm} -> S.def path tm, tp
   in

--- a/src/refiner/rules/Structural.ml
+++ b/src/refiner/rules/Structural.ml
@@ -17,9 +17,11 @@ let global_var path shift : T.infer =
   T.Infer.rule @@ fun _ ->
   let ulvl = T.Shift.run shift in
   let tm, tp =
-    match Eff.resolve {value = path ; loc = Eff.loc()} with
-    | ResolveData.Axiom {tp} -> S.axiom path, tp
-    | ResolveData.Def {tp; tm} -> S.def path tm, tp
+    match Eff.resolve path with
+    | Some ResolveData.Axiom {tp} -> S.axiom path, tp
+    | Some ResolveData.Def {tp; tm} -> S.def path tm, tp
+    | None -> Error.Logger.fatalf ?loc:(Eff.loc ()) ~code:NotInScope "The variable '%a' is not in scope" S.dump_name path
+
   in
   S.app tm (Eff.quote ulvl), NbE.app_ulvl ~tp ~ulvl
 

--- a/src/refiner/rules/Univ.ml
+++ b/src/refiner/rules/Univ.ml
@@ -9,10 +9,9 @@ let univ shift =
     then S.univ (Eff.quote vsmall)
     else begin
       let pp_lvl = Mugen.Syntax.Free.dump NbE.ULvl.Shift.dump Format.pp_print_int in
-      Format.eprintf "@[<2>Universe@ level@ %a@ is@ not@ smaller@ than@ %a@]@."
-        pp_lvl (UL.of_con vsmall)
-        pp_lvl (UL.of_con large);
-      invalid_arg "univ"
+      Error.Logger.fatalf ?loc:(Eff.loc ()) ~code:IllTyped "@[<2>Universe@ level@ %a@ is@ not@ smaller@ than@ %a@]@."
+      pp_lvl (UL.of_con vsmall)
+      pp_lvl (UL.of_con large)
     end
-  | _ ->
-    invalid_arg "univ"
+  | tp ->
+    Error.Connective.check ?loc:(Eff.loc ()) `Univ S.dump (Eff.quote tp)

--- a/src/refiner/rules/Univ.ml
+++ b/src/refiner/rules/Univ.ml
@@ -10,8 +10,8 @@ let univ shift =
     else begin
       let pp_lvl = Mugen.Syntax.Free.dump NbE.ULvl.Shift.dump Format.pp_print_int in
       Error.Logger.fatalf ?loc:(Eff.loc ()) ~code:IllTyped "@[<2>Universe@ level@ %a@ is@ not@ smaller@ than@ %a@]@."
-      pp_lvl (UL.of_con vsmall)
-      pp_lvl (UL.of_con large)
+        pp_lvl (UL.of_con vsmall)
+        pp_lvl (UL.of_con large)
     end
   | tp ->
     Error.Connective.check ?loc:(Eff.loc ()) `Univ S.dump (Eff.quote tp)

--- a/src/refiner/rules/Univ.ml
+++ b/src/refiner/rules/Univ.ml
@@ -5,7 +5,7 @@ let univ shift =
   match goal.tp with
   | D.Univ large ->
     let vsmall = T.Shift.run shift in
-    if UL.(<) (UL.of_con vsmall) (UL.of_con large)
+    if UL.lt (UL.of_con vsmall) (UL.of_con large)
     then S.univ (Eff.quote vsmall)
     else begin
       let pp_lvl = Mugen.Syntax.Free.dump NbE.ULvl.Shift.dump Format.pp_print_int in


### PR DESCRIPTION
This is take two of worshiping Asai in Algaett, now updated to use the new API.

Closes https://github.com/RedPRL/algaett/issues/18
Helps with https://github.com/RedPRL/algaett/issues/16
This PR ditches the low Ch'i "errors are sum types that we propagate with exceptions and sometimes catch" approach to error messages, and adopts the Asai library, where errors are effects that carry diagnostic information.

The exact error messages that are being used now are not final, and we should strive to continually make them more useful!

To get Asai working you will need to

opam repo add alpha git+https://github.com/kit-ty-kate/opam-alpha-repository.git
Asai also pins algaeff to the github repo, while algaett just uses the package on opam.

To get ocaml-lsp-server working with VSCode and Asai you will need to

opam pin git+https://github.com/patricoferris/ocaml-lsp#87ab11a7a88b6e47205736d972c3c4af79ee2a7e
opam unpin lsp
opam unpin jsonrpc
opam install lsp
opam install jsonrpc
This stuff should get put in a Makefile